### PR TITLE
Add a check for unique image ID in ValidCOCO

### DIFF
--- a/ethology/annotations/validators.py
+++ b/ethology/annotations/validators.py
@@ -212,4 +212,8 @@ class ValidCOCO:
 
         # Check for duplicate image IDs
         if n_images != len(unique_image_ids):
-            raise ValueError("The image IDs are not unique.")
+            raise ValueError(
+                "The image IDs in the input COCO file are not unique. "
+                f"There are {n_images} image entries, but only "
+                f"{len(unique_image_ids)} unique image IDs."
+            )

--- a/ethology/annotations/validators.py
+++ b/ethology/annotations/validators.py
@@ -191,3 +191,25 @@ class ValidCOCO:
                         f" for {_singularise_err_msg(ky)} {instance_dict}"
                     ),
                 )
+
+    @path.validator
+    def _file_contains_unique_image_IDs(self, attribute, value):
+        """Ensure that the COCO JSON file contains unique image IDs.
+
+        When exporting to COCO format, the VIA tool attempts to extract the
+        image ID from the filename using ``parseInt``. If two images have the
+        same number-based filename, the image IDs can be duplicated. This is
+        probably a bug in the VIA tool, but we need to check for this issue.
+        """
+        with open(value) as file:
+            data = json.load(file)
+
+        # Get number of elements in "images" list
+        n_images = len(data["images"])
+
+        # Get the image IDs
+        unique_image_ids = set([img["id"] for img in data["images"]])
+
+        # Check for duplicate image IDs
+        if n_images != len(unique_image_ids):
+            raise ValueError("The image IDs are not unique.")

--- a/ethology/annotations/validators.py
+++ b/ethology/annotations/validators.py
@@ -197,8 +197,9 @@ class ValidCOCO:
         """Ensure that the COCO JSON file contains unique image IDs.
 
         When exporting to COCO format, the VIA tool attempts to extract the
-        image ID from the filename using ``parseInt``. If two images have the
-        same number-based filename, the image IDs can be duplicated. This is
+        image ID from the image filename using ``parseInt``. As a result, if
+        two or more images have the same number-based filename, the image IDs
+        can be non-unique (i.e., more image filenames than image IDs). This is
         probably a bug in the VIA tool, but we need to check for this issue.
         """
         with open(value) as file:

--- a/tests/test_unit/test_annotations/test_validators.py
+++ b/tests/test_unit/test_annotations/test_validators.py
@@ -495,3 +495,22 @@ def test_null_category_ID_behaviour(annotations_test_data):
     # Throws a schema validation error because category IDs are not integer
     with pytest.raises(jsonschema.exceptions.ValidationError):
         _ = ValidCOCO(path=filepath)
+
+
+def test_COCO_non_unique_image_IDs(annotations_test_data: dict):
+    """Check the COCO validator throws an error when the input file contains
+    non-unique image IDs.
+    """
+    # Get path to test file
+    filepath = annotations_test_data[
+        "small_bboxes_non_unique_img_id_COCO.json"
+    ]
+
+    # Throws a schema validation error because image IDs are not unique
+    with pytest.raises(ValueError) as excinfo:
+        _ = ValidCOCO(path=filepath)
+
+    assert str(excinfo.value) == (
+        "The image IDs in the input COCO file are not unique. "
+        "There are 4 image entries, but only 3 unique image IDs."
+    )

--- a/tests/test_unit/test_annotations/test_validators.py
+++ b/tests/test_unit/test_annotations/test_validators.py
@@ -461,7 +461,10 @@ def test_required_keys_in_provided_COCO_schema(
     ],
 )
 def test_no_categories_behaviour(
-    validator, input_file, expected_exception, annotations_test_data
+    validator: type[ValidVIA | ValidCOCO],
+    input_file: str,
+    expected_exception: pytest.raises,
+    annotations_test_data: dict,
 ):
     """Test the behaviour of the validators when the input file does not
     specify any categories.
@@ -485,7 +488,7 @@ def test_no_categories_behaviour(
         ) in str(excinfo.value)
 
 
-def test_null_category_ID_behaviour(annotations_test_data):
+def test_null_category_ID_behaviour(annotations_test_data: dict):
     """Test the behaviour of the validators when the input file contains
     annotations with null category IDs.
     """

--- a/tests/test_unit/test_annotations/test_validators.py
+++ b/tests/test_unit/test_annotations/test_validators.py
@@ -504,12 +504,10 @@ def test_COCO_non_unique_image_IDs(annotations_test_data: dict):
     """Check the COCO validator throws an error when the input file contains
     non-unique image IDs.
     """
-    # Get path to test file
     filepath = annotations_test_data[
         "small_bboxes_non_unique_img_id_COCO.json"
     ]
 
-    # Throws a schema validation error because image IDs are not unique
     with pytest.raises(ValueError) as excinfo:
         _ = ValidCOCO(path=filepath)
 


### PR DESCRIPTION
## Description

With the current implementation, if we have two images with the same name, the associated annotations have different `image_id`s, except in _some cases_ when exporting the data in VIA to COCO forma -  I suspect this is a bug in the VIA tool (because COCO requires image IDs and image files to be mapped 121).

When exporting in COCO format, the VIA tool tries to extract the image ID from the filename using [parseInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt). If two files have the same name, they show up as two different elements in the `"images"` list but they will have the same image ID after parseInt. Which renders the annotations that refer to that image ID unusable, because we cannot distinguish which image they refer to. 

I think the culprit is around [here](https://gitlab.com/vgg/via/-/blob/master/via-2.x.y/src/via.js?ref_type=heads#L1288).

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
To ensure the annotation data we read in ethology has unique image IDs.

**What does this PR do?**
Adds a check to the ValidCOCO class.

## References

Came up during the review of #31 

## How has this PR been tested?

Tests pass locally and in CI

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

\

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
