### PR TITLE
Make image ID 0-based and consistent across COCO and VIA

### DIFF
--- a/ethology/annotations/io/load_bboxes.py
+++ b/ethology/annotations/io/load_bboxes.py
@@ -122,7 +122,8 @@ def _from_multiple_files(
     # NOTE: after ignore_index=True the index name is no longer "annotation_id"
     df_all = pd.concat(df_list, ignore_index=True)
 
-    # Update "image_id" based on the full sorted list of image filenames
+    # Update "image_id" based on the alphabetically sorted list of unique image
+    # filenames across all input files
     list_image_filenames = sorted(list(df_all["image_filename"].unique()))
     df_all["image_id"] = df_all["image_filename"].apply(
         lambda x: list_image_filenames.index(x)
@@ -216,18 +217,14 @@ def _df_rows_from_valid_VIA_file(file_path: Path) -> list[dict]:
 
     # Prepare data
     image_metadata_dict = data_dict["_via_img_metadata"]
-    via_image_id_list = [str(x) for x in data_dict["_via_image_id_list"]]
+    list_sorted_filenames = sorted(
+        [img_dict["filename"] for img_dict in image_metadata_dict.values()]
+    )
+
     via_attributes = data_dict["_via_attributes"]
     supercategories_props = {}
     if "region" in via_attributes:
         supercategories_props = via_attributes["region"]
-
-    # Map image filenames to the image keys used by VIA
-    # the VIA keys are <filename><filesize> strings
-    map_filename_to_via_img_id = {
-        img_dict["filename"]: ky
-        for ky, img_dict in image_metadata_dict.items()
-    }
 
     # Get list of rows in dataframe
     list_rows = []
@@ -256,9 +253,7 @@ def _df_rows_from_valid_VIA_file(file_path: Path) -> list[dict]:
             row = {
                 "annotation_id": annotation_id,
                 "image_filename": img_dict["filename"],
-                "image_id": via_image_id_list.index(
-                    map_filename_to_via_img_id[img_dict["filename"]]
-                ),  # integer based on the VIA image ID
+                "image_id": list_sorted_filenames.index(img_dict["filename"]),
                 "x_min": region_shape["x"],
                 "y_min": region_shape["y"],
                 "width": region_shape["width"],

--- a/ethology/annotations/io/load_bboxes.py
+++ b/ethology/annotations/io/load_bboxes.py
@@ -294,13 +294,20 @@ def _df_rows_from_valid_COCO_file(file_path: Path) -> list[dict]:
         data_dict = json.load(file)
 
     # Prepare data
-    map_image_id_to_filename = {
-        img_dict["id"]: img_dict["file_name"]
-        for img_dict in data_dict["images"]
+    # We define image_id_ethology as the 0-based index of the image in the
+    # "images" list of the COCO JSON file. The following assumes the number of
+    # unique image_ids in the input COCO file matches the number of elements
+    # in the "images" list.
+    map_img_id_coco_to_ethology = {
+        img_dict["id"]: idx for idx, img_dict in enumerate(data_dict["images"])
     }
-    map_image_id_to_width_height = {
-        img_dict["id"]: (img_dict["width"], img_dict["height"])
-        for img_dict in data_dict["images"]
+    map_img_id_ethology_to_filename = {
+        idx: img_dict["file_name"]
+        for idx, img_dict in enumerate(data_dict["images"])
+    }
+    map_img_id_ethology_to_wh = {
+        idx: (img_dict["width"], img_dict["height"])
+        for idx, img_dict in enumerate(data_dict["images"])
     }
 
     map_category_id_to_category_data = {
@@ -314,10 +321,12 @@ def _df_rows_from_valid_COCO_file(file_path: Path) -> list[dict]:
         annotation_id = annot_dict["id"]
 
         # image data
-        image_id = annot_dict["image_id"]
-        image_filename = map_image_id_to_filename[image_id]
-        image_width = map_image_id_to_width_height[image_id][0]
-        image_height = map_image_id_to_width_height[image_id][1]
+        img_id_coco = annot_dict["image_id"]
+        img_id_ethology = map_img_id_coco_to_ethology[img_id_coco]
+
+        image_filename = map_img_id_ethology_to_filename[img_id_ethology]
+        image_width = map_img_id_ethology_to_wh[img_id_ethology][0]
+        image_height = map_img_id_ethology_to_wh[img_id_ethology][1]
 
         # bbox data
         x_min, y_min, width, height = annot_dict["bbox"]
@@ -329,7 +338,7 @@ def _df_rows_from_valid_COCO_file(file_path: Path) -> list[dict]:
         row = {
             "annotation_id": annotation_id,
             "image_filename": image_filename,
-            "image_id": image_id,
+            "image_id": img_id_ethology,
             "image_width": image_width,
             "image_height": image_height,
             "x_min": x_min,

--- a/ethology/annotations/io/load_bboxes.py
+++ b/ethology/annotations/io/load_bboxes.py
@@ -294,17 +294,19 @@ def _df_rows_from_valid_COCO_file(file_path: Path) -> list[dict]:
     # unique image_ids in the input COCO file matches the number of elements
     # in the "images" list.
     map_img_id_coco_to_ethology = {
-        img_dict["id"]: idx for idx, img_dict in enumerate(data_dict["images"])
+        img_dict["id"]: idx
+        for idx, img_dict in enumerate(
+            sorted(data_dict["images"], key=lambda x: x["file_name"])
+        )
     }
-    map_img_id_ethology_to_filename = {
-        idx: img_dict["file_name"]
-        for idx, img_dict in enumerate(data_dict["images"])
+    map_img_id_coco_to_filename = {
+        img_dict["id"]: img_dict["file_name"]
+        for img_dict in data_dict["images"]
     }
-    map_img_id_ethology_to_wh = {
-        idx: (img_dict["width"], img_dict["height"])
-        for idx, img_dict in enumerate(data_dict["images"])
+    map_img_id_coco_to_width_height = {
+        img_dict["id"]: (img_dict["width"], img_dict["height"])
+        for img_dict in data_dict["images"]
     }
-
     map_category_id_to_category_data = {
         cat_dict["id"]: (cat_dict["name"], cat_dict["supercategory"])
         for cat_dict in data_dict["categories"]
@@ -317,11 +319,13 @@ def _df_rows_from_valid_COCO_file(file_path: Path) -> list[dict]:
 
         # image data
         img_id_coco = annot_dict["image_id"]
-        img_id_ethology = map_img_id_coco_to_ethology[img_id_coco]
+        image_filename = map_img_id_coco_to_filename[img_id_coco]
+        image_width, image_height = map_img_id_coco_to_width_height[
+            img_id_coco
+        ]
 
-        image_filename = map_img_id_ethology_to_filename[img_id_ethology]
-        image_width = map_img_id_ethology_to_wh[img_id_ethology][0]
-        image_height = map_img_id_ethology_to_wh[img_id_ethology][1]
+        # compute image ID following ethology convention
+        img_id_ethology = map_img_id_coco_to_ethology[img_id_coco]
 
         # bbox data
         x_min, y_min, width, height = annot_dict["bbox"]

--- a/ethology/annotations/validators.py
+++ b/ethology/annotations/validators.py
@@ -51,7 +51,7 @@ class ValidVIA:
     )
     required_keys: dict = field(
         default={
-            "main": ["_via_img_metadata", "_via_image_id_list"],
+            "main": ["_via_img_metadata", "_via_attributes"],
             "images": ["filename"],
             "regions": ["shape_attributes"],
             "shape_attributes": ["x", "y", "width", "height"],

--- a/tests/test_unit/test_annotations/test_load_bboxes.py
+++ b/tests/test_unit/test_annotations/test_load_bboxes.py
@@ -236,7 +236,7 @@ def test_from_single_file_unsupported():
         ("small_bboxes_COCO.json", "COCO"),  # small COCO file
     ],
 )
-def test_from_single_file(  # --------------> remove format?
+def test_from_single_file(
     input_file: str,
     format: Literal["VIA", "COCO"],
     annotations_test_data: dict,
@@ -269,14 +269,13 @@ def test_from_single_file(  # --------------> remove format?
 
 
 @pytest.mark.parametrize(
-    ("input_file, format"),
+    ("format"),
     [
-        ("small_bboxes_duplicates_VIA.json", "VIA"),
-        ("small_bboxes_duplicates_COCO.json", "COCO"),
-    ],  # in both, one annotation is duplicated in the first frame
+        "VIA",
+        "COCO",
+    ],
 )
 def test_from_single_file_duplicates(
-    input_file: str,
     format: Literal["VIA", "COCO"],
     annotations_test_data: dict,
 ):
@@ -284,7 +283,9 @@ def test_from_single_file_duplicates(
     contains duplicate annotations.
     """
     # Properties of input data
-    filepath = annotations_test_data[input_file]
+    # in the "small_bboxes_duplicates_" files, one annotation is duplicated
+    # in the first frame
+    filepath = annotations_test_data[f"small_bboxes_duplicates_{format}.json"]
     expected_n_images, expected_n_annotations_w_duplicates = (
         count_imgs_and_annots_in_input_file(filepath, format=format)
     )
@@ -292,7 +293,9 @@ def test_from_single_file_duplicates(
 
     # Compute bboxes dataframe
     df = _from_single_file(
-        file_path=annotations_test_data[input_file],
+        file_path=annotations_test_data[
+            f"small_bboxes_duplicates_{format}.json"
+        ],
         format=format,
     )
 
@@ -308,22 +311,19 @@ def test_from_single_file_duplicates(
 
 
 @pytest.mark.parametrize(
-    ("input_file, format, expected_exception"),
+    ("format, expected_exception"),
     [
         (
-            "small_bboxes_no_cat_VIA.json",
             "VIA",
             does_not_raise(),
         ),
         (
-            "small_bboxes_no_cat_COCO.json",
             "COCO",
             pytest.raises(ValueError),
         ),
     ],
 )
 def test_from_single_file_no_category(
-    input_file: str,
     format: Literal["VIA", "COCO"],
     expected_exception: pytest.raises,
     annotations_test_data: dict,
@@ -335,7 +335,9 @@ def test_from_single_file_no_category(
     # (this should raise an error for COCO files)
     with expected_exception as excinfo:
         df = _from_single_file(
-            file_path=annotations_test_data[input_file],
+            file_path=annotations_test_data[
+                f"small_bboxes_no_cat_{format}.json"
+            ],
             format=format,
         )
 
@@ -480,7 +482,9 @@ def test_from_files_duplicates(
         "COCO",
     ],
 )
-def test_image_id_assignment(format, annotations_test_data):
+def test_image_id_assignment(
+    format: Literal["VIA", "COCO"], annotations_test_data: dict
+):
     """Test if the bboxes dataframe image_id is assigned based on the
     alphabetically sorted list of filenames.
     """

--- a/tests/test_unit/test_annotations/test_load_bboxes.py
+++ b/tests/test_unit/test_annotations/test_load_bboxes.py
@@ -524,3 +524,26 @@ def test_image_id_assignment(
         for file, id in zip(df["image_filename"], df["image_id"], strict=True)
     }
     assert pairs_img_id_filename_out == pairs_img_id_to_filename_alphabetical
+
+
+def test_dataframe_from_same_annotations(annotations_test_data: dict):
+    """Test whether the same annotations exported to VIA and COCO formats
+    produce the same dataframe, except for the image width and height columns.
+
+    We use the `_subset` files because we know they contain the
+    same annotations.
+    """
+    # Read data into dataframes
+    df_via = from_files(
+        annotations_test_data["small_bboxes_VIA_subset.json"],
+        format="VIA",
+    )
+    df_coco = from_files(
+        annotations_test_data["small_bboxes_COCO_subset.json"],
+        format="COCO",
+    )
+
+    # Compare dataframes excluding `image_width`, `image_height` columns
+    assert df_via.drop(columns=["image_width", "image_height"]).equals(
+        df_coco.drop(columns=["image_width", "image_height"])
+    )


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [X] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Initially I wanted to keep the image ID if specified in the input file. 

In VIA format, the image ID is not specified as such - I was taking it based on the order of the list `_via_image_id_list`, so it is currently always 0-based. 

In COCO, the image ID is specified: it is either extracted programmatically from the image filename (without extension), or if that is not possible, it is assigned a 1-based index. When the image ID is extracted programmatically, I found some issues with the image IDs sometimes being non-unique (see #40).

Therefore I think for consistency between the two formats and for simplicity I will not aim to retain the image IDs specified in the COCO file and simply always reindex the images using 0-based indices. I use the alphabetically sorted list of image filenames to determine the index for each image (see PR #40).

**What does this PR do?**
- Defines an ethology image ID that is 0-based and is derived from the sorted list of image filenames.
- Implements the ethology image ID in the VIA loader
- Implements the ethology image ID in the COCO loader
- Adds tests
    - to check the image ID is based on alphabetical order of files
    - to verify the same set of annotations exported to VIA or COCO format give rise to the same dataframe, except for the `image_width` and `image_height` columns (because the VIA format does not retain this data, see issue #46 ).
- Removes filenames from the tests' parametrizations when most of the string except the format is common across tests.

## References

- PR #40

- PR #45 --- see closing comment

## How has this PR been tested?

Tests pass locally and in CI.

## Is this a breaking change?

\

## Does this PR require an update to the documentation?

This is covered in #47 

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
