### PR TITLE
Explain image ID assignment in docstring

### DIFF
--- a/ethology/annotations/io/load_bboxes.py
+++ b/ethology/annotations/io/load_bboxes.py
@@ -29,7 +29,7 @@ def from_files(
     format: Literal["VIA", "COCO"],
     images_dirs: Path | str | list[Path | str] | None = None,
 ) -> pd.DataFrame:
-    """Read bounding boxes annotations as a dataframe.
+    """Read input annotation files as a bboxes dataframe.
 
     Parameters
     ----------
@@ -49,7 +49,21 @@ def from_files(
         "image_id", "image_width", "image_height", "x_min", "y_min",
         "width", "height", "supercategory", "category". It also has the
         following attributes: "annotation_files", "annotation_format",
-        "images_directories".
+        "images_directories". The "image_id" is assigned based
+        on the alphabetically sorted list of unique image filenames across all
+        input files.
+
+    Notes
+    -----
+    We use image filenames' to assign IDs to images, so if two images have the
+    same name but are in different input annotation files, they will be
+    assigned the same image ID and their annotations will be merged.
+
+    If this behaviour is not desired, and you would like to assign different
+    image IDs to images that have the same name but appear in different input
+    annotation files, you can either make the image filenames distinct before
+    loading the data, or you can load the data from each file
+    as a separate dataframe, and then concatenate them as desired.
 
     See Also
     --------

--- a/ethology/annotations/io/load_bboxes.py
+++ b/ethology/annotations/io/load_bboxes.py
@@ -47,7 +47,9 @@ def from_files(
         Bounding boxes annotations dataframe. The dataframe is indexed
         by "annotation_id" and has the following columns: "image_filename",
         "image_id", "image_width", "image_height", "x_min", "y_min",
-        "width", "height", "supercategory", "category".
+        "width", "height", "supercategory", "category". It also has the
+        following attributes: "annotation_files", "annotation_format",
+        "images_directories".
 
     See Also
     --------
@@ -65,9 +67,9 @@ def from_files(
 
     # Add metadata
     df_all.attrs = {
-        "input_files": file_paths,
-        "format": format,
-        "images_dirs": images_dirs,
+        "annotation_files": file_paths,
+        "annotation_format": format,
+        "images_directories": images_dirs,
     }
 
     return df_all

--- a/tests/test_unit/test_annotations/test_load_bboxes.py
+++ b/tests/test_unit/test_annotations/test_load_bboxes.py
@@ -169,10 +169,10 @@ def test_from_files(
         mock.assert_called_once_with(file_path, format=format)
 
     # Check metadata
-    assert df.attrs["input_files"] == file_path
-    assert df.attrs["format"] == format
+    assert df.attrs["annotation_files"] == file_path
+    assert df.attrs["annotation_format"] == format
     if images_dirs:
-        assert df.attrs["images_dirs"] == images_dirs
+        assert df.attrs["images_directories"] == images_dirs
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
From #41: I decided the best way to make the user aware of the possible "risks" of having common image filenames across annotation files is to explain clearly in the docstring how the image ID is computed.

For the reviewer: if interested, my current thoughts about this are in the [closing comment](https://github.com/neuroinformatics-unit/ethology/pull/45#issuecomment-2656231701) of PR 41.

**What does this PR do?**
- It explains how the image ID is computed in the `load_from_files` docstring.
- It also renames the metadata attributes for clarity.

## References

From PR #41 

## How has this PR been tested?
Tests pass locally and in CI.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

\
## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
