### PR TITLE
Add category ID to bboxes dataframe and sort by filename

### DIFF
--- a/ethology/annotations/io/load_bboxes.py
+++ b/ethology/annotations/io/load_bboxes.py
@@ -52,8 +52,9 @@ def from_files(
         following attributes: "annotation_files", "annotation_format",
         "images_directories". The "image_id" is assigned based
         on the alphabetically sorted list of unique image filenames across all
-        input files. The "category_id" column is always a 0-based integer, 
-        except for VIA files where the values specified in the input file are retained.
+        input files. The "category_id" column is always a 0-based integer,
+        except for VIA files where the values specified in the input file
+        are retained.
 
     Notes
     -----
@@ -333,9 +334,7 @@ def _df_rows_from_valid_COCO_file(file_path: Path) -> list[dict]:
 
     # Build standard dataframe
     list_rows = []
-    for annot_dict in data_dict["annotations"]:
-        annotation_id = annot_dict["id"]
-
+    for annot_id, annot_dict in enumerate(data_dict["annotations"]):
         # image data
         img_id_coco = annot_dict["image_id"]
         image_filename = map_img_id_coco_to_filename[img_id_coco]
@@ -354,7 +353,7 @@ def _df_rows_from_valid_COCO_file(file_path: Path) -> list[dict]:
         category, supercategory = map_category_id_to_category_data[category_id]
 
         row = {
-            "annotation_id": annotation_id,
+            "annotation_id": annot_id,
             "image_filename": image_filename,
             "image_id": img_id_ethology,
             "image_width": image_width,

--- a/ethology/annotations/io/load_bboxes.py
+++ b/ethology/annotations/io/load_bboxes.py
@@ -197,6 +197,11 @@ def _from_single_file(
     # Cast as an int if possible, otherwise factorize it
     if format == "VIA" and not df["category_id"].isna().all():
         df = _VIA_category_id_as_int(df)
+    elif format == "COCO":
+        # In COCO files exported with the VIA tool, the category_id
+        # is always a 1-based integer. Here we coerce it to a 0-based
+        # integer
+        df["category_id"] = df["category"].factorize(sort=True)[0]
 
     # Reorder columns to match standard columns
     # If columns dont exist they are filled with nan / na values
@@ -364,7 +369,7 @@ def _df_rows_from_valid_COCO_file(file_path: Path) -> list[dict]:
             "height": height,
             "supercategory": supercategory,
             "category": category,
-            "category_id": category_id - 1,
+            "category_id": category_id,
             # in COCO files, the category_id is always a 1-based integer
         }
 

--- a/ethology/annotations/io/load_bboxes.py
+++ b/ethology/annotations/io/load_bboxes.py
@@ -52,7 +52,8 @@ def from_files(
         following attributes: "annotation_files", "annotation_format",
         "images_directories". The "image_id" is assigned based
         on the alphabetically sorted list of unique image filenames across all
-        input files.
+        input files. The "category_id" column is always a 0-based integer, 
+        except for VIA files where the values specified in the input file are retained.
 
     Notes
     -----
@@ -109,7 +110,7 @@ def _from_multiple_files(
         Bounding boxes annotations dataframe. The dataframe is indexed
         by "annotation_id" and has the following columns: "image_filename",
         "image_id", "image_width", "image_height", "x_min", "y_min",
-        "width", "height", "supercategory", "category".
+        "width", "height", "supercategory", "category", "category_id".
 
     """
     # Get list of dataframes
@@ -161,7 +162,7 @@ def _from_single_file(
         Bounding boxes annotations dataframe. The dataframe is indexed
         by "annotation_id" and has the following columns: "image_filename",
         "image_id", "image_width", "image_height", "x_min", "y_min",
-        "width", "height", "supercategory", "category".
+        "width", "height", "supercategory", "category", "category_id".
 
     """
     # Choose the appropriate validator and row-extraction function

--- a/ethology/annotations/io/load_bboxes.py
+++ b/ethology/annotations/io/load_bboxes.py
@@ -180,8 +180,8 @@ def _from_single_file(
     list_rows = get_rows_from_file(valid_file.path)
     df = pd.DataFrame(list_rows)
 
-    # Sort by annotation_id and image_filename
-    df = df.sort_values(by=["annotation_id", "image_filename"])
+    # Sort annotations by image_filename
+    df = df.sort_values(by=["image_filename"])
 
     # Drop duplicates and reindex
     # The resulting axis is labeled 0,1,…,n-1.

--- a/ethology/annotations/io/load_bboxes.py
+++ b/ethology/annotations/io/load_bboxes.py
@@ -194,10 +194,7 @@ def _from_single_file(
     # Fix category_id for VIA files if required
     # Cast as an int if possible, otherwise factorize it
     if format == "VIA" and not df["category_id"].isna().all():
-        try:
-            df["category_id"] = df["category_id"].astype(int)
-        except ValueError:
-            df["category_id"] = df["category"].factorize(sort=True)[0]
+        df = _VIA_category_id_as_int(df)
 
     # Reorder columns to match standard columns
     # If columns dont exist they are filled with nan / na values
@@ -373,3 +370,24 @@ def _df_rows_from_valid_COCO_file(file_path: Path) -> list[dict]:
         list_rows.append(row)
 
     return list_rows
+
+
+def _VIA_category_id_as_int(df: pd.DataFrame) -> pd.DataFrame:
+    """Convert category_id to int if possible, otherwise factorize it.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Bounding boxes annotations dataframe.
+
+    Returns
+    -------
+    pd.DataFrame
+        Bounding boxes annotations dataframe with "category_id" as int.
+
+    """
+    try:
+        df["category_id"] = df["category_id"].astype(int)
+    except ValueError:
+        df["category_id"] = df["category"].factorize(sort=True)[0]
+    return df

--- a/ethology/annotations/io/load_bboxes.py
+++ b/ethology/annotations/io/load_bboxes.py
@@ -364,7 +364,8 @@ def _df_rows_from_valid_COCO_file(file_path: Path) -> list[dict]:
             "height": height,
             "supercategory": supercategory,
             "category": category,
-            "category_id": category_id,
+            "category_id": category_id - 1,
+            # in COCO files, the category_id is always a 1-based integer
         }
 
         list_rows.append(row)

--- a/ethology/annotations/io/load_bboxes.py
+++ b/ethology/annotations/io/load_bboxes.py
@@ -19,9 +19,10 @@ STANDARD_BBOXES_DF_COLUMNS = [
     "height",
     "supercategory",
     "category",
+    "category_id",
     "image_width",
     "image_height",
-]  # if a column is not defined, it is filled with nan
+]
 
 
 def from_files(
@@ -346,6 +347,7 @@ def _df_rows_from_valid_COCO_file(file_path: Path) -> list[dict]:
             "height": height,
             "supercategory": supercategory,
             "category": category,
+            "category_id": category_id,
         }
 
         list_rows.append(row)

--- a/tests/test_unit/test_annotations/test_load_bboxes.py
+++ b/tests/test_unit/test_annotations/test_load_bboxes.py
@@ -349,8 +349,9 @@ def test_from_single_file_no_category(
         )
     # If no error expected, check that the dataframe has empty categories
     else:
-        assert all(df.loc[:, "category"] == "")
-        assert all(df.loc[:, "supercategory"] == "")
+        assert df["category"].isna().all()
+        assert df["supercategory"].isna().all()
+        assert df["category_id"].isna().all()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unit/test_annotations/test_load_bboxes.py
+++ b/tests/test_unit/test_annotations/test_load_bboxes.py
@@ -597,3 +597,50 @@ def test_category_id_extraction(
     elif input_category_type == "string_category":
         assert df["category_id"].dtype == int
         assert all(df["category_id"] == df["category"].factorize()[0])
+
+
+@pytest.mark.parametrize(
+    "input_file_type, format",
+    [
+        ("single", "VIA"),  # ----> need a different one to test this
+        ("multiple", "VIA"),
+        ("single", "COCO"),
+        ("multiple", "COCO"),
+    ],
+)
+def test_sorted_annotations_by_image_filename(
+    input_file_type: str,
+    format: Literal["VIA", "COCO"],
+    annotations_test_data: dict,
+    # multiple_files: dict,
+):
+    """Test that the annotations are sorted by image filename.
+
+    We use the small_bboxes_image_id_ data because the image filenames are not
+    sorted in the original files.
+    """
+    # Get input file(s)
+    if input_file_type == "single":
+        input_filepaths = annotations_test_data[
+            f"small_bboxes_image_id_{format}.json"
+        ]
+    elif input_file_type == "multiple":
+        # they should be loaded in this order for the image filemanes to not
+        # be sorted alphabetically across the files
+        input_files = (
+            ["VIA_JSON_sample_2.json", "VIA_JSON_sample_1.json"]
+            if format == "VIA"
+            else ["COCO_JSON_sample_1.json", "COCO_JSON_sample_2.json"]
+        )
+        input_filepaths = [annotations_test_data[file] for file in input_files]
+
+    # Compute bboxes dataframe
+    df = from_files(
+        file_paths=input_filepaths,
+        format=format,
+    )
+
+    # Check that the annotations are sorted by image filename
+    assert df["image_filename"].to_list() == sorted(
+        df["image_filename"].to_list()
+    )

--- a/tests/test_unit/test_annotations/test_load_bboxes.py
+++ b/tests/test_unit/test_annotations/test_load_bboxes.py
@@ -573,10 +573,14 @@ def test_dataframe_from_same_annotations(annotations_test_data: dict):
         format="COCO",
     )
 
-    # Compare dataframes excluding `image_width`, `image_height` columns
-    assert df_via.drop(columns=["image_width", "image_height"]).equals(
-        df_coco.drop(columns=["image_width", "image_height"])
+    # Compare dataframes excluding `image_width`, `image_height` and
+    # `category_id` columns
+    assert df_via.drop(
+        columns=["image_width", "image_height", "category_id"]
+    ).equals(
+        df_coco.drop(columns=["image_width", "image_height", "category_id"])
     )
+
 
 @pytest.mark.parametrize(
     "input_file, format, case_category_id, expected_category_id",


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Currently, the category ID is not added to the dataframe. However, this may be useful information to retain (for example, it could be used to annotate behaviours per bbox). 

In this PR, I add the category ID to the bboxes dataframe. I wanted to retain the category ID as specified in the input file (because it may refer to a user-defined classification) but this is only possible in the VIA tool if exporting to a VIA file.
-  In the VIA format, the category ID is exported as specified in the VIA tool. 
- However in COCO format, the category ID is always exported as a 1-based index. For consistency with the rest of IDs in the dataframe, I coerce the category ID in the COCO file to a 0-based index. 

**What does this PR do?**
This PR adds category ID to the dataframe and deals with the possible types in which the category ID can be specified.
- In COCO format, the category ID is always(*) a 1-based index. We transform it to a 0-based one.
- In VIA format, the category ID can be defined or undefined. If it is undefined, it is set to `None` in the dataframe (along with `category` and `supercategory`). If it is defined, it is read as a string and cast as an integer if possible, otherwise factorized.

This PR also:
- Adds tests to confirm the category ID is handled as expected
- Adds a step to sort the annotations in the dataframe by image filename (and adds a test for this).
- Replaces the NA/missing value for `category` and `supercategory` from an empty string ("") to `None`. This is because an empty string is not considered an NA value by `pandas`.

**Question**
I forced the category ID to be 0-based if the data is read from a COCO file - however this makes it very specific to COCO files _exported using the VIA tool_. Should I drop this then? The downside is the inconsistency between 0-based IDs (for images and annotations) and 1-based IDs (for category IDs imported from COCO files generated in the VIA tool 🫠 )


## References
(*) In reality the category ID in COCO may be exported as `null` if in the VIA tool it is specified as a string, but this is already caught by the file validator via the JSON schema type validation.

In this PR I retain the category ID as specified in the input file if possible. This is contrary to the image ID or annotation ID, which are always coerced to being 0-based. The reasoning is that the category ID may carry a semantic meaning, whereas that is not the case for the other two.

I added the gotcha re the category ID differences between VIA and COCO files to the manual labelling guide in the crabs repo (see PR [263](https://github.com/SainsburyWellcomeCentre/crabs-exploration/pull/263))

## How has this PR been tested?

Tests pass locally and in CI.

## Is this a breaking change?

\

## Does this PR require an update to the documentation?

\

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
