### PR TITLE
base dataset module

### DIFF
--- a/ethology/datasets/dataset.py
+++ b/ethology/datasets/dataset.py
@@ -1,38 +1,58 @@
+"""Base dataset module for COCO-style object detection."""
+
+from collections.abc import Callable
 from pathlib import Path
-from typing import Optional, Callable
+
 import pandas as pd
-from PIL import Image
 import torch
-from torch.utils.data import Dataset
 import torchvision
+from PIL import Image
+from torch.utils.data import Dataset
+
 
 class BaseImageDataset(Dataset):
-    """Base dataset module for loading annotated images for COCO-style object detection.
-    
+    """Dataset for loading annotated images for COCO-style object detection.
+
     Parameters
     ----------
     annotations_df : pd.DataFrame
-        DataFrame with columns: 'image_id', 'image_filename', 'bbox', 'category_id'.
-        This DataFrame should contain the COCO-style annotations.
+        DataFrame with columns:
+        'image_id', 'image_filename', 'bbox', 'category_id'.
+        This DataFrame contains the COCO-style annotations.
     images_dir : str | Path
         Directory containing the images.
     transform : callable, optional
-        Transform to be applied to images (e.g., torchvision transforms like Resize, ToTensor).
+        Transform to apply (e.g., torchvision.transforms like Resize,
+        ToTensor).
+
     """
-    
+
     def __init__(
         self,
         annotations_df: pd.DataFrame,
         images_dir: str | Path,
-        transform: Optional[Callable] = None
+        transform: Callable | None = None,
     ):
+        """Initialize the dataset.
+
+        Parameters
+        ----------
+        annotations_df : pd.DataFrame
+            DataFrame with columns:
+            'image_id', 'image_filename', 'bbox', 'category_id'.
+        images_dir : str | Path
+            Directory containing the images.
+        transform : Callable, optional
+            Transform function to be applied to images.
+
+        """
         self.annotations_df = annotations_df
         self.images_dir = Path(images_dir)
         self.transform = transform
 
         # Group annotations by image_id for efficient lookup
         self.grouped_annotations = annotations_df.groupby("image_id")
-        
+
         # Get unique image metadata (image_id and image_filename)
         self.image_data = (
             annotations_df[["image_id", "image_filename"]]
@@ -45,22 +65,23 @@ class BaseImageDataset(Dataset):
         return len(self.image_data)
 
     def __getitem__(self, idx: int) -> tuple:
-        """Retrieve an image tensor and its corresponding target dictionary for detection tasks.
-        
+        """Retrieve an image tensor and its corresponding target dictionary.
+
         Parameters
         ----------
         idx : int
             Index of the image to retrieve.
-            
+
         Returns
         -------
         tuple
             A tuple containing:
                 - image: Tensor representing the image.
-                - target: Dictionary with the following keys:
-                    'boxes' : Tensor of shape [N, 4] with bounding box coordinates.
-                    'labels': Tensor of shape [N] with category labels.
-                    'image_id': Tensor containing the image identifier.
+                - target: Dictionary with:
+                    - 'boxes' : Tensor [N, 4] (bounding boxes).
+                    - 'labels': Tensor [N] (category labels).
+                    - 'image_id': Tensor (image identifier).
+
         """
         # Get image metadata
         image_info = self.image_data.iloc[idx]
@@ -78,13 +99,15 @@ class BaseImageDataset(Dataset):
         # Get annotations for this image
         annotations = self.grouped_annotations.get_group(image_id)
         boxes = torch.tensor(annotations["bbox"].tolist(), dtype=torch.float32)
-        labels = torch.tensor(annotations["category_id"].tolist(), dtype=torch.int64)
+        labels = torch.tensor(
+            annotations["category_id"].tolist(), dtype=torch.int64
+        )
 
         # Create target dictionary
         target = {
             "boxes": boxes,
             "labels": labels,
-            "image_id": torch.tensor([image_id], dtype=torch.int64)
+            "image_id": torch.tensor([image_id], dtype=torch.int64),
         }
 
         return image, target

--- a/ethology/datasets/dataset.py
+++ b/ethology/datasets/dataset.py
@@ -1,0 +1,80 @@
+"""Base dataset module for loading annotated images."""
+
+from pathlib import Path
+from typing import Optional, Callable
+
+import pandas as pd
+from PIL import Image
+import torch
+from torch.utils.data import Dataset
+
+class BaseImageDataset(Dataset):
+    """Basic dataset for loading annotated images.
+    
+    Parameters
+    ----------
+    annotations_df : pd.DataFrame
+        DataFrame containing annotations with required columns:
+        'image_filename', 'image_id'
+    images_dir : str | Path
+        Directory containing the images
+    transform : callable, optional
+        Optional transform to be applied to images
+    """
+    
+    def __init__(
+        self,
+        annotations_df: pd.DataFrame,
+        images_dir: str | Path,
+        transform: Optional[Callable] = None
+    ):
+        self.annotations = annotations_df
+        self.images_dir = Path(images_dir)
+        self.transform = transform
+        
+        # Get unique image IDs and filenames
+        self.image_data = (
+            self.annotations[["image_id", "image_filename"]]
+            .drop_duplicates()
+            .reset_index(drop=True)
+        )
+        
+    def __len__(self) -> int:
+        """Return the number of images in the dataset."""
+        return len(self.image_data)
+    
+    def __getitem__(self, idx: int) -> dict:
+        """Get an image and its metadata.
+        
+        Parameters
+        ----------
+        idx : int
+            Index of the image to get
+            
+        Returns
+        -------
+        dict
+            Dictionary containing:
+                - image: PIL Image or transformed image
+                - image_id: unique identifier for the image
+                - filename: original image filename
+        """
+        # Get image info
+        image_info = self.image_data.iloc[idx]
+        image_id = image_info["image_id"]
+        filename = image_info["image_filename"]
+        
+        # Load image
+        image_path = self.images_dir / filename
+        image = Image.open(image_path)
+        
+        # Apply transforms if any
+        if self.transform is not None:
+            image = self.transform(image)
+            
+        return {
+            "image": image,
+            "image_id": image_id,
+            "filename": filename
+        }
+    

--- a/ethology/datasets/dataset.py
+++ b/ethology/datasets/dataset.py
@@ -1,25 +1,23 @@
-"""Base dataset module for loading annotated images."""
-
 from pathlib import Path
 from typing import Optional, Callable
-
 import pandas as pd
 from PIL import Image
 import torch
 from torch.utils.data import Dataset
+import torchvision
 
 class BaseImageDataset(Dataset):
-    """Basic dataset for loading annotated images.
+    """Base dataset module for loading annotated images for COCO-style object detection.
     
     Parameters
     ----------
     annotations_df : pd.DataFrame
-        DataFrame containing annotations with required columns:
-        'image_filename', 'image_id'
+        DataFrame with columns: 'image_id', 'image_filename', 'bbox', 'category_id'.
+        This DataFrame should contain the COCO-style annotations.
     images_dir : str | Path
-        Directory containing the images
+        Directory containing the images.
     transform : callable, optional
-        Optional transform to be applied to images
+        Transform to be applied to images (e.g., torchvision transforms like Resize, ToTensor).
     """
     
     def __init__(
@@ -28,53 +26,65 @@ class BaseImageDataset(Dataset):
         images_dir: str | Path,
         transform: Optional[Callable] = None
     ):
-        self.annotations = annotations_df
+        self.annotations_df = annotations_df
         self.images_dir = Path(images_dir)
         self.transform = transform
+
+        # Group annotations by image_id for efficient lookup
+        self.grouped_annotations = annotations_df.groupby("image_id")
         
-        # Get unique image IDs and filenames
+        # Get unique image metadata (image_id and image_filename)
         self.image_data = (
-            self.annotations[["image_id", "image_filename"]]
+            annotations_df[["image_id", "image_filename"]]
             .drop_duplicates()
             .reset_index(drop=True)
         )
-        
+
     def __len__(self) -> int:
         """Return the number of images in the dataset."""
         return len(self.image_data)
-    
-    def __getitem__(self, idx: int) -> dict:
-        """Get an image and its metadata.
+
+    def __getitem__(self, idx: int) -> tuple:
+        """Retrieve an image tensor and its corresponding target dictionary for detection tasks.
         
         Parameters
         ----------
         idx : int
-            Index of the image to get
+            Index of the image to retrieve.
             
         Returns
         -------
-        dict
-            Dictionary containing:
-                - image: PIL Image or transformed image
-                - image_id: unique identifier for the image
-                - filename: original image filename
+        tuple
+            A tuple containing:
+                - image: Tensor representing the image.
+                - target: Dictionary with the following keys:
+                    'boxes' : Tensor of shape [N, 4] with bounding box coordinates.
+                    'labels': Tensor of shape [N] with category labels.
+                    'image_id': Tensor containing the image identifier.
         """
-        # Get image info
+        # Get image metadata
         image_info = self.image_data.iloc[idx]
         image_id = image_info["image_id"]
         filename = image_info["image_filename"]
-        
-        # Load image
         image_path = self.images_dir / filename
-        image = Image.open(image_path)
-        
-        # Apply transforms if any
-        if self.transform is not None:
+
+        image = Image.open(image_path).convert("RGB")
+        if self.transform:
             image = self.transform(image)
-            
-        return {
-            "image": image,
-            "image_id": image_id,
-            "filename": filename
+        else:
+            # Default: Convert PIL image to tensor if no transform is provided
+            image = torchvision.transforms.functional.to_tensor(image)
+
+        # Get annotations for this image
+        annotations = self.grouped_annotations.get_group(image_id)
+        boxes = torch.tensor(annotations["bbox"].tolist(), dtype=torch.float32)
+        labels = torch.tensor(annotations["category_id"].tolist(), dtype=torch.int64)
+
+        # Create target dictionary
+        target = {
+            "boxes": boxes,
+            "labels": labels,
+            "image_id": torch.tensor([image_id], dtype=torch.int64)
         }
-    
+
+        return image, target


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Addition of a new feature
- [ ] Bug fix
- [ ] Other

**Why is this PR needed?**
To add basic dataset functionality that allows loading annotated images using PyTorch's Dataset class. 

**What does this PR do?**
- Adds to the `datasets` module:
  - `BaseImageDataset`: A basic PyTorch Dataset class for loading images and their annotations


## References

Related to Issue #51: Add a dataset module

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)