### PR TITLE
Cotracker napari widget integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ venv/
 
 # written by setuptools_scm
 **/_version.py
+
+# processed videos
+/ethology/video/*.mp4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ethology/trackers/cotracker"]
+	path = ethology/trackers/cotracker
+	url = https://github.com/facebookresearch/co-tracker.git

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,9 +9,12 @@ recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 recursive-exclude docs *
 recursive-exclude tests *
+global-exclude .git
 
 # Include json schemas
 recursive-include ethology/annotations/json_schemas/schemas *.json
 recursive-include ethology/annotations/json_schemas/schemas *.md
 
 recursive-include examples *.py
+
+recursive-include ethology/trackers/cotracker *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include LICENSE
 include README.md
 include CONTRIBUTING.md
+include .gitmodules
 
 exclude .pre-commit-config.yaml
 
@@ -12,3 +13,5 @@ recursive-exclude tests *
 # Include json schemas
 recursive-include ethology/annotations/json_schemas/schemas *.json
 recursive-include ethology/annotations/json_schemas/schemas *.md
+
+recursive-include examples *.py

--- a/README.md
+++ b/README.md
@@ -8,15 +8,16 @@
 
 # ethology
 
-
 ## Installation
 
 First clone the repository at the desired location:
+
 ```bash
 git clone https://github.com/neuroinformatics-unit/ethology.git
 ```
 
 Then create a conda environment and install the package from source
+
 ```
 conda create -n ethology-env python=3.12 -y
 conda activate ethology-env
@@ -25,6 +26,16 @@ pip install .
 ```
 
 To install the package in editable mode with developer dependencies, replace the last command with:
+
 ```
 pip install -e .[dev]  # in mac: pip install -e ".[dev]"
+```
+
+---
+
+Using cotracker requires running the following in terminal
+
+```bash
+git submodule init
+git submodule update
 ```

--- a/ethology/trackers/__init__.py
+++ b/ethology/trackers/__init__.py
@@ -1,1 +1,2 @@
 """Trackers to apply on bboxes or kpt detections."""
+from ethology.trackers.tracker import BaseTracker

--- a/ethology/trackers/tracker.py
+++ b/ethology/trackers/tracker.py
@@ -41,7 +41,8 @@ class BaseTracker:
          query_points: list
          save_results: bool
         Returns:
-         path of each point cross the frames [Batch, Frames, X, Y].
+         path of each point cross the frames
+            [Batch, n_frames, n_keypoints, n_space=2].
 
         """
         # check if video source file exists in path

--- a/ethology/trackers/tracker.py
+++ b/ethology/trackers/tracker.py
@@ -1,0 +1,98 @@
+"""Trackers module."""
+
+import os
+from typing import Literal
+
+import torch
+
+from .cotracker.cotracker.utils.visualizer import (
+    Visualizer,
+    read_video_from_path,
+)
+
+
+class BaseTracker:
+    """Base class for all trackers.
+
+    Args:
+     video_source: str
+     query_points: list
+     tracker: str
+
+    """
+
+    def __init__(self, tracker_type: Literal["cotracker"]):
+        """Initialize the tracker."""
+        if tracker_type not in ["cotracker"]:
+            raise ValueError(f"Tracker type {tracker_type} not supported yet")
+
+        self.tracker = tracker_type
+
+    def track(
+        self,
+        video_source: str,
+        query_points: list[list],
+        save_results: bool = False,
+    ) -> torch.Tensor:
+        """Track the query points in the video source.
+
+        Args:
+         video_source: str
+         query_points: list
+         save_results: bool
+        Returns:
+         path of each point cross the frames [Batch, Frames, X, Y].
+
+        """
+        # check if video source file exists in path
+        if not os.path.isfile(video_source):
+            raise FileNotFoundError(
+                f"Video source file {video_source} not found"
+            )
+        else:
+            print(f"Video source file {video_source} found")
+
+        # load video
+        video = read_video_from_path(video_source)
+
+        # (Frames, Height, Width, Channels) ->
+        # (Batch, Frames, Channels, Height, Width)
+        video = torch.from_numpy(video).permute(0, 3, 1, 2)[None].float()
+
+        # load model
+        if self.tracker == "cotracker":
+            model = torch.hub.load(
+                "facebookresearch/co-tracker", "cotracker3_offline"
+            )
+
+        # List to tensor
+        query_tensor = torch.tensor(query_points, dtype=torch.float32)
+
+        # set device
+        device = (
+            torch.device("cuda")
+            if torch.cuda.is_available()
+            else torch.device("cpu")
+        )
+
+        model = model.to(device)
+        video = video.to(device)
+        query_tensor = query_tensor.to(device)
+
+        pred_tracks, pred_visibility = model(video, queries=query_tensor[None])
+
+        if save_results:
+            vis = Visualizer(
+                save_dir="../ethology/video",
+                linewidth=6,
+                mode="cool",
+                tracks_leave_trace=-1,
+            )
+            vis.visualize(
+                video=video,
+                tracks=pred_tracks,
+                visibility=pred_visibility,
+                filename=f'{self.tracker}_{video_source.split("/")[-1].split(".")[0]}',
+            )
+
+        return pred_tracks

--- a/examples/napari_point_tracking.py
+++ b/examples/napari_point_tracking.py
@@ -1,0 +1,169 @@
+from typing import List
+
+import napari
+import pandas as pd
+from dask_image.imread import imread
+from magicgui.widgets import ComboBox, Container, PushButton
+
+from ethology.trackers import BaseTracker
+
+COLOR_CYCLE = [
+    '#1f77b4',
+    '#ff7f0e',
+    '#2ca02c',
+    '#d62728',
+    '#9467bd',
+    '#8c564b',
+    '#e377c2',
+    '#7f7f7f',
+    '#bcbd22',
+    '#17becf'
+]
+
+
+def create_label_menu(points_layer, labels):
+    """Create a label menu widget that can be added to the napari viewer dock
+
+    Parameters
+    ----------
+    points_layer : napari.layers.Points
+        a napari points layer
+    labels : List[str]
+        list of the labels for each keypoint to be annotated (e.g., the body parts to be labeled).
+
+    Returns
+    -------
+    label_menu : Container
+        the magicgui Container with our dropdown menu widget
+    """
+    # Create the label selection menu
+    label_menu = ComboBox(label='feature_label', choices=labels)
+    label_widget = Container(widgets=[label_menu])
+
+
+    def update_label_menu(event):
+        """Update the label menu when the point selection changes"""
+        new_label = str(points_layer.feature_defaults['label'][0])
+        if new_label != label_menu.value:
+            label_menu.value = new_label
+
+    points_layer.events.feature_defaults.connect(update_label_menu)
+
+    def label_changed(selected_label):
+        """Update the Points layer when the label menu selection changes"""
+        feature_defaults = points_layer.feature_defaults
+        feature_defaults['label'] = selected_label
+        points_layer.feature_defaults = feature_defaults
+        points_layer.refresh_colors()
+
+    label_menu.changed.connect(label_changed)
+
+    return label_widget
+
+def create_cotrack_runner(vid_path, points_layer, labels):
+    """Create a label menu widget that can be added to the napari viewer dock
+
+    Parameters
+    ----------
+    points_layer : napari.layers.Points
+        a napari points layer
+    labels : List[str]
+        list of the labels for each keypoint to be annotated (e.g., the body parts to be labeled).
+
+    Returns
+    -------
+    label_menu : Container
+        the magicgui Container with our dropdown menu widget
+    """
+    # Create the label selection menu
+    # label_menu = ComboBox(label='feature_label', choices=labels)
+    button = PushButton(text="Run tracker on selected points.")
+
+    cotrack_widget = Container(widgets=[button])
+
+    @button.clicked.connect
+    def on_button_click():
+        tracker = BaseTracker(tracker_type="cotracker")
+        # Output is in shape [n_batch=1, n_frames, n_keypoints, n_space=2]
+        trajectories = tracker.track(vid_path, points_layer.data, save_results=True)
+
+    return cotrack_widget
+
+def point_annotator(
+        vid_path: str,
+        labels: List[str],
+):
+    """Create a GUI for annotating points in a series of images.
+
+    Parameters
+    ----------
+    vid_path : str
+        glob-like string for the video to be labeled.
+    labels : List[str]
+        list of the labels for each keypoint to be annotated (e.g., the body parts to be labeled).
+    """
+    stack = imread(vid_path)
+
+    viewer = napari.view_image(stack)
+    points_layer = viewer.add_points(
+        ndim=3,
+        features=pd.DataFrame({'label': pd.Categorical([], categories=labels)}),
+        border_color='label',
+        border_color_cycle=COLOR_CYCLE,
+        symbol='o',
+        face_color='transparent',
+        border_width=0.5,  # fraction of point size
+        size=12,
+    )
+    points_layer.border_color_mode = 'cycle'
+
+    # add the label menu widget to the viewer
+    label_widget = create_label_menu(points_layer, labels)
+    cotrack_widget = create_cotrack_runner(vid_path, points_layer, labels)
+
+
+    viewer.window.add_dock_widget(label_widget)
+    viewer.window.add_dock_widget(cotrack_widget)
+
+    @viewer.bind_key('.')
+    def next_label(event=None):
+        """Keybinding to advance to the next label with wraparound"""
+        feature_defaults = points_layer.feature_defaults
+        default_label = feature_defaults['label'][0]
+        ind = list(labels).index(default_label)
+        new_ind = (ind + 1) % len(labels)
+        new_label = labels[new_ind]
+        feature_defaults['label'] = new_label
+        points_layer.feature_defaults = feature_defaults
+        points_layer.refresh_colors()
+
+    def next_on_click(layer, event):
+        """Mouse click binding to advance the label when a point is added"""
+        if layer.mode == 'add':
+            # By default, napari selects the point that was just added.
+            # Disable that behavior, as the highlight gets in the way
+            # and also causes next_label to change the color of the
+            # point that was just added.
+            layer.selected_data = set()
+            next_label()
+
+    points_layer.mode = 'add'
+    points_layer.mouse_drag_callbacks.append(next_on_click)
+
+    @viewer.bind_key(',')
+    def prev_label(event):
+        """Keybinding to decrement to the previous label with wraparound"""
+        feature_defaults = points_layer.feature_defaults
+        default_label = feature_defaults['label'][0]
+        ind = list(labels).index(default_label)
+        n_labels = len(labels)
+        new_ind = ((ind - 1) + n_labels) % n_labels
+        feature_defaults['label'] = labels[new_ind]
+        points_layer.feature_defaults = feature_defaults
+        points_layer.refresh_colors()
+
+    napari.run()
+
+
+video_source = "apple.mov"
+point_annotator(video_source, ['stem', 'core'])

--- a/examples/tracking_using_cotracker.py
+++ b/examples/tracking_using_cotracker.py
@@ -1,0 +1,16 @@
+"""Example of tracking using the cotracker."""
+
+from ethology.trackers import BaseTracker
+
+video_source = "../ethology/trackers/cotracker/assets/apple.mp4"
+
+query_points = [
+    [0, 400, 350],  # frame_number, x, y
+    [0, 600, 500],
+    [0, 750, 600],
+    [0, 900, 200],
+]
+
+tracker = BaseTracker(tracker_type="cotracker")
+
+path = tracker.track(video_source, query_points, save_results=True)

--- a/examples/tracking_using_cotracker.py
+++ b/examples/tracking_using_cotracker.py
@@ -1,5 +1,7 @@
 """Example of tracking using the cotracker."""
 
+from movement.io import load_poses
+
 from ethology.trackers import BaseTracker
 
 video_source = "../ethology/trackers/cotracker/assets/apple.mp4"
@@ -13,4 +15,13 @@ query_points = [
 
 tracker = BaseTracker(tracker_type="cotracker")
 
-path = tracker.track(video_source, query_points, save_results=True)
+# Output is in shape [n_batch=1, n_frames, n_keypoints, n_space=2]
+trajectories = tracker.track(video_source, query_points, save_results=True)
+
+# Movement needs arrays shaped (n_frames, n_space, n_keypoints, n_individuals)
+# Assume n_batch = 1 = n_individuals
+ds = load_poses.from_numpy(
+    trajectories.numpy().transpose(1, 3, 2, 0), source_software="cotracker"
+)
+
+print(ds)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
   "check-manifest",
   "types-PyYAML",
   "types-requests",
+  "torch",
 ]
 
 # [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ dev = [
   "types-PyYAML",
   "types-requests",
   "torch",
-]
+  "torchvision"
+  ]
 
 # [project.scripts]
 # movement = "movement.cli_entrypoint:main"


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/neuroinformatics-unit/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Tracker needs a front-end interface to go with it to make it user-friendly.
 
**What does this PR do?**

This is a **prototype** [napari](https://napari.org/stable/) window, that allows the user to load a video and select the query points to track. There is also a button that allows the user to run the tracker. At the moment this outputs the video, but it can of course be extended to output a `movement` dataset.

![image](https://github.com/user-attachments/assets/3d7cb277-1730-478e-b339-525271e548ef)
_Screenshot of the Napari window_

<img width="583" alt="image" src="https://github.com/user-attachments/assets/45c83dc5-d137-48ee-acee-41cdec1e6012" />

_Screenshot of the output of the tracker, with points labelled using the Napari GUI_

I'm still learning the ropes of napari, but I thought it would be nice to have a minimal demo first to illustrate the concept of the GUI. I am looking forward to inspecting the movement library and perhaps I can mirror its structure to create a proper napari 'plugin.'

## References

Please reference any existing issues/PRs that relate to this PR.

#54
#58 

## How has this PR been tested?

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

## Is this a breaking change?

If this PR breaks any existing functionality, please explain how and why.

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the
documentation has been updated.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
