### PR TITLE
Retrieve version in docs config using importlib.metadata

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,8 +3,7 @@
 
 import os
 import sys
-
-import setuptools_scm
+from importlib.metadata import version as get_version
 
 # Used when building API docs, put the dependencies
 # of any class you are documenting here
@@ -19,7 +18,7 @@ project = "ethology"
 copyright = "2024, University College London"
 author = "Adam Tyson"
 try:
-    release = setuptools_scm.get_version(root="../..", relative_to=__file__)
+    release = get_version("ethology")
     release = release.split("+")[0]  # remove git hash
 except LookupError:
     # if git is not initialised, still allow local build


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
To follow recommended usage from [setuptools-scm docs](https://setuptools-scm.readthedocs.io/en/latest/usage/#via-setuptools_scm-strongly-discouraged)

**What does this PR do?**
Replaces the version retrieval from `setuptools_scm.get_version` ---> `importlib.metadata.get_version` as recommended.

## References
\

## How has this PR been tested?

Tests pass locally and in CI.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

\

## Checklist:

- [x] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [ n/a ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
