### PR TITLE
Revisit how image size is saved to the annotations dataframe #46

### DIFF
--- a/tests/test_unit/test_annotations/test_load_bboxes.py
+++ b/tests/test_unit/test_annotations/test_load_bboxes.py
@@ -687,3 +687,33 @@ def test_sorted_annotations_by_image_filename(
     assert df["image_filename"].to_list() == sorted(
         df["image_filename"].to_list()
     )
+
+
+@pytest.mark.parametrize(
+    "input_file, format, expected_width, expected_height",
+    [
+        # COCO with consistent size
+        ("small_bboxes_COCO_same_size.json", "COCO", 640, 480),
+        # COCO with variable size
+        ("small_bboxes_COCO_varied_size.json", "COCO", "variable", "variable"),
+        # VIA should return None or unknown for both
+        ("small_bboxes_VIA.json", "VIA", None, None),
+    ],
+)
+def test_image_size_metadata_in_dataframe(
+    input_file: str,
+    format: Literal["VIA", "COCO"],
+    expected_width: int | str | None,
+    expected_height: int | str | None,
+    annotations_test_data: dict,
+):
+    """Test that image width/height metadata is correctly inferred and stored
+    in the dataframe attributes when loading bboxes from files.
+    """
+    # Load file
+    filepath = annotations_test_data[input_file]
+    df = from_files(filepath, format=format)
+
+    # Check metadata in dataframe attributes
+    assert df.attrs.get("image_width") == expected_width
+    assert df.attrs.get("image_height") == expected_height


### PR DESCRIPTION


## Description
This PR updates the logic in load_bboxes.py to infer image size metadata (image_width, image_height) when loading annotations from files.

**What is this PR**

- [ ] Bug fix
- [✔] Addition of a new feature
- [ ] Other

**What does this PR do?**

This PR addresses [Issue #46] by implementing logic to infer and store image size metadata (image_width and image_height) when loading bounding box annotations.
For COCO files:
- If all images have the same dimensions, store width/height in df.attrs.
- If dimensions vary or are missing, mark as "variable".
For VIA:
- Set both to "unknown" by default.
Dropped image_width and image_height columns from the DataFrame when consistent values are stored in attrs.

## References

https://github.com/neuroinformatics-unit/ethology/issues/46

## How has this PR been tested?

Added a new parameterized test: test_image_size_metadata_in_dataframe to verify:
- Consistent image sizes in COCO → correctly stored in df.attrs.
- Variable image sizes → marked as "variable".
- VIA format → metadata set to "unknown".

Ran the full test suite using pytest; ~96% of tests passed.
Fixed failing tests related to formatting and pre-commit hooks (e.g., mixed line endings, trailing whitespace).
Still working on fixing a few test failures (related to COCO files).

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

Yes, For VIA files, image_width and image_height metadata fields are initialized as "unknown". Instructions for the user (in docs) to set the value of these metadata fields needs to be written. [suggested by @niksirbi]

## Checklist:

- [✔] The code has been tested locally
- [✔] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [✔] The code has been formatted with [pre-commit](https://pre-commit.com/)
