### PR TITLE
Add tag filter step to docs and PyPI workflows

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -35,7 +35,7 @@ jobs:
     name: Build Sphinx Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: neuroinformatics-unit/actions/build_sphinx_docs@main
+      - uses: neuroinformatics-unit/actions/build_sphinx_docs@v2
         with:
           python-version: 3.13 # default for the action is 3.x
           use-make: true
@@ -48,7 +48,7 @@ jobs:
     outputs:
       tag_on_main: ${{ steps.check.outputs.tag_on_main }}
     steps:
-      - uses: neuroinformatics-unit/actions/check_tag_on_main@tags-filter
+      - uses: neuroinformatics-unit/actions/check_tag_on_main@v2
         id: check
 
   deploy_sphinx_docs:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -54,7 +54,7 @@ jobs:
       tag_on_main: ${{ steps.check.outputs.tag_on_main }}
     runs-on: ubuntu-latest
     steps:
-      - uses: neuroinformatics-unit/actions/check_tag_on_main@tags-filter
+      - uses: neuroinformatics-unit/actions/check_tag_on_main@v2
         id: check
 
   build_sdist_wheels:


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
At the moment, pushing a tag linked to a commit in any branch triggers the docs and PyPI deployments. 

**What does this PR do?**
Modifies workflow to only deploy docs or to PyPI if a tag is pushed, starts with `v` and is on `main`.

## References

It uses the action defined in [this PR](https://github.com/neuroinformatics-unit/actions/pull/119)

## How has this PR been tested?
The actions in this PR work as expected re pushed tags.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ \ ] Tests have been added to cover all new functionality
- [ \ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
