### PR TITLE
Add tracks dataset validator and movement→ethology bbox loader

### DIFF
--- a/ethology/io/tracks.py
+++ b/ethology/io/tracks.py
@@ -1,0 +1,125 @@
+"""Load tracked bounding box datasets into ``ethology`` format.
+
+This module provides utilities to construct an ``ethology`` bounding box
+tracks dataset from an existing ``movement`` bounding boxes dataset.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import numpy as np
+import xarray as xr
+
+from ethology.validators.detections import ValidBboxTracksDataset
+from ethology.validators.utils import _check_output
+
+
+def _require_dims(dataset: xr.Dataset, required_dims: Iterable[str]) -> None:
+    """Raise a ValueError if any of the required dims are missing."""
+    missing = set(required_dims) - set(dataset.dims)
+    if missing:
+        raise ValueError(
+            "Expected a movement-like dataset with dimensions "
+            f"{sorted(required_dims)}, but missing {sorted(missing)}."
+        )
+
+
+def _require_vars(dataset: xr.Dataset, required_vars: Iterable[str]) -> None:
+    """Raise a ValueError if any of the required data variables are missing."""
+    missing = set(required_vars) - set(dataset.data_vars)
+    if missing:
+        raise ValueError(
+            "Expected a movement-like dataset with data variables "
+            f"{sorted(required_vars)}, but missing {sorted(missing)}."
+        )
+
+
+@_check_output(ValidBboxTracksDataset)
+def from_movement_bboxes(movement_ds: xr.Dataset) -> xr.Dataset:
+    """Create a bounding box tracks dataset from a ``movement`` dataset.
+
+    Parameters
+    ----------
+    movement_ds : xarray.Dataset
+        Input bounding boxes dataset in ``movement`` format. It is expected
+        to have at least the following:
+
+        - dimensions: ``time``, ``space``, ``individuals``,
+        - data variables: ``position`` and ``shape``.
+
+        Optionally, it may contain:
+
+        - ``category``: (time, individuals),
+        - ``confidence``: (time, individuals).
+
+    Returns
+    -------
+    xarray.Dataset
+        A valid ``ethology`` bounding box tracks dataset with dimensions
+        ``image_id``, ``space`` and ``id`` and data variables
+        ``position``, ``shape``, ``category`` and ``confidence``. The
+        dataset is validated using
+        :class:`ethology.validators.detections.ValidBboxTracksDataset`.
+
+    Raises
+    ------
+    ValueError
+        If the input dataset does not contain the expected dimensions
+        or data variables.
+
+    Notes
+    -----
+    The conversion is purely structural: the function renames the
+    ``movement`` dimensions ``time`` → ``image_id`` and
+    ``individuals`` → ``id`` and forwards the core variables and
+    attributes. If ``category`` or ``confidence`` are missing, they
+    are created with default values (``-1`` for category, indicating
+    unknown category, and ``NaN`` for confidence).
+
+    """
+    # Basic checks that this looks like a movement-like bbox dataset
+    _require_dims(movement_ds, {"time", "space", "individuals"})
+    _require_vars(movement_ds, {"position", "shape"})
+
+    # Rename movement-style dimensions to ethology-style
+    ds = movement_ds.rename({"time": "image_id", "individuals": "id"})
+
+    # Start building the output dataset with required variables
+    out = xr.Dataset(
+        data_vars={
+            "position": ds["position"],
+            "shape": ds["shape"],
+        },
+        coords={
+            "image_id": ds.coords.get(
+                "image_id", ds["position"].coords["image_id"]
+            ),
+            "space": ds.coords.get("space", ds["position"].coords["space"]),
+            "id": ds.coords.get("id", ds["position"].coords["id"]),
+        },
+        attrs=dict(ds.attrs),
+    )
+
+    n_images = out.sizes["image_id"]
+    n_ids = out.sizes["id"]
+
+    # Category: forward if present, otherwise fill with -1 (unknown)
+    if "category" in ds.data_vars:
+        out["category"] = ds["category"]
+    else:
+        out["category"] = xr.DataArray(
+            np.full((n_images, n_ids), -1, dtype=int),
+            dims=("image_id", "id"),
+        )
+
+    # Confidence: forward if present, otherwise fill with NaN
+    if "confidence" in ds.data_vars:
+        out["confidence"] = ds["confidence"]
+    else:
+        out["confidence"] = xr.DataArray(
+            np.full((n_images, n_ids), np.nan, dtype=float),
+            dims=("image_id", "id"),
+        )
+
+    return out

--- a/ethology/io/tracks.py
+++ b/ethology/io/tracks.py
@@ -1,7 +1,7 @@
 """Load tracked bounding box datasets into ``ethology`` format.
 
-This module provides utilities to construct an ``ethology`` bounding box
-tracks dataset from an existing ``movement`` bounding boxes dataset.
+Convert a ``movement`` bounding box dataset into an ``ethology`` tracks
+dataset (dimensions and variables renamed, output validated).
 """
 
 from collections.abc import Iterable
@@ -68,12 +68,10 @@ def from_movement_bboxes(movement_ds: xr.Dataset) -> xr.Dataset:
 
     Notes
     -----
-    The conversion is purely structural: the function renames the
-    ``movement`` dimensions ``time`` → ``image_id`` and
-    ``individuals`` → ``id`` and forwards the core variables and
-    attributes. If ``category`` or ``confidence`` are missing, they
-    are created with default values (``-1`` for category, indicating
-    unknown category, and ``NaN`` for confidence).
+    Renames ``movement`` dimensions ``time`` → ``image_id`` and
+    ``individuals`` → ``id``, forwards ``position``, ``shape`` and
+    attributes. Missing ``category`` or ``confidence`` are added
+    (``-1`` and ``NaN`` respectively).
 
     """
     _require_dims(movement_ds, {"time", "space", "individuals"})
@@ -86,11 +84,9 @@ def from_movement_bboxes(movement_ds: xr.Dataset) -> xr.Dataset:
             "shape": ds["shape"],
         },
         coords={
-            "image_id": ds.coords.get(
-                "image_id", ds["position"].coords["image_id"]
-            ),
-            "space": ds.coords.get("space", ds["position"].coords["space"]),
-            "id": ds.coords.get("id", ds["position"].coords["id"]),
+            "image_id": ds.coords["image_id"],
+            "space": ds.coords["space"],
+            "id": ds.coords["id"],
         },
         attrs=dict(ds.attrs),
     )

--- a/ethology/io/tracks.py
+++ b/ethology/io/tracks.py
@@ -12,6 +12,9 @@ import xarray as xr
 from ethology.validators.detections import ValidBboxTracksDataset
 from ethology.validators.utils import _check_output
 
+_REQUIRED_DIMS = {"time", "space", "individuals"}
+_REQUIRED_VARS = {"position", "shape"}
+
 
 def _require_dims(dataset: xr.Dataset, required_dims: Iterable[str]) -> None:
     """Check required dimensions exist; raise ValueError if not."""
@@ -74,8 +77,8 @@ def from_movement_bboxes(movement_ds: xr.Dataset) -> xr.Dataset:
     (``-1`` and ``NaN`` respectively).
 
     """
-    _require_dims(movement_ds, {"time", "space", "individuals"})
-    _require_vars(movement_ds, {"position", "shape"})
+    _require_dims(movement_ds, _REQUIRED_DIMS)
+    _require_vars(movement_ds, _REQUIRED_VARS)
 
     ds = movement_ds.rename({"time": "image_id", "individuals": "id"})
     out = xr.Dataset(

--- a/ethology/io/tracks.py
+++ b/ethology/io/tracks.py
@@ -4,8 +4,6 @@ This module provides utilities to construct an ``ethology`` bounding box
 tracks dataset from an existing ``movement`` bounding boxes dataset.
 """
 
-from __future__ import annotations
-
 from collections.abc import Iterable
 
 import numpy as np
@@ -16,7 +14,7 @@ from ethology.validators.utils import _check_output
 
 
 def _require_dims(dataset: xr.Dataset, required_dims: Iterable[str]) -> None:
-    """Raise a ValueError if any of the required dims are missing."""
+    """Check required dimensions exist; raise ValueError if not."""
     missing = set(required_dims) - set(dataset.dims)
     if missing:
         raise ValueError(
@@ -26,7 +24,7 @@ def _require_dims(dataset: xr.Dataset, required_dims: Iterable[str]) -> None:
 
 
 def _require_vars(dataset: xr.Dataset, required_vars: Iterable[str]) -> None:
-    """Raise a ValueError if any of the required data variables are missing."""
+    """Check required data variables exist; raise ValueError if not."""
     missing = set(required_vars) - set(dataset.data_vars)
     if missing:
         raise ValueError(
@@ -78,14 +76,10 @@ def from_movement_bboxes(movement_ds: xr.Dataset) -> xr.Dataset:
     unknown category, and ``NaN`` for confidence).
 
     """
-    # Basic checks that this looks like a movement-like bbox dataset
     _require_dims(movement_ds, {"time", "space", "individuals"})
     _require_vars(movement_ds, {"position", "shape"})
 
-    # Rename movement-style dimensions to ethology-style
     ds = movement_ds.rename({"time": "image_id", "individuals": "id"})
-
-    # Start building the output dataset with required variables
     out = xr.Dataset(
         data_vars={
             "position": ds["position"],
@@ -104,7 +98,6 @@ def from_movement_bboxes(movement_ds: xr.Dataset) -> xr.Dataset:
     n_images = out.sizes["image_id"]
     n_ids = out.sizes["id"]
 
-    # Category: forward if present, otherwise fill with -1 (unknown)
     if "category" in ds.data_vars:
         out["category"] = ds["category"]
     else:
@@ -113,7 +106,6 @@ def from_movement_bboxes(movement_ds: xr.Dataset) -> xr.Dataset:
             dims=("image_id", "id"),
         )
 
-    # Confidence: forward if present, otherwise fill with NaN
     if "confidence" in ds.data_vars:
         out["confidence"] = ds["confidence"]
     else:

--- a/ethology/validators/detections.py
+++ b/ethology/validators/detections.py
@@ -63,3 +63,64 @@ class ValidBboxDetectionsDataset(ValidDataset):
         "category": {"image_id", "id"},
         "confidence": {"image_id", "id"},
     }
+
+
+@define
+class ValidBboxTracksDataset(ValidDataset):
+    """Class for valid ``ethology`` bounding box tracks datasets.
+
+    This class validates that the input dataset:
+
+    - is an xarray Dataset,
+    - has ``image_id``, ``space``, ``id`` as dimensions,
+    - has ``position``, ``shape``, ``category`` and ``confidence`` as data
+      variables,
+    - ``position`` and ``shape`` span at least the dimensions ``image_id``,
+      ``space`` and ``id``,
+    - ``category`` and ``confidence`` span at least the dimensions
+      ``image_id`` and ``id``.
+
+    Semantically, in a tracks dataset the ``id`` dimension identifies the
+    same individual across different ``image_id`` (frames), unlike in an
+    annotations dataset where ``id`` is only a per-frame slot.
+
+    Attributes
+    ----------
+    dataset : xarray.Dataset
+        The xarray dataset to validate.
+    required_dims : typing.ClassVar[set]
+        The set of required dimension names: ``image_id``, ``space`` and
+        ``id``.
+    required_data_vars : typing.ClassVar[dict[str, set]]
+        A dictionary mapping data variable names to their required minimum
+        dimensions:
+
+        - ``position`` maps to ``image_id``, ``space`` and ``id``,
+        - ``shape`` maps to ``image_id``, ``space`` and ``id``,
+        - ``category`` maps to ``image_id`` and ``id``,
+        - ``confidence`` maps to ``image_id`` and ``id``.
+
+    Raises
+    ------
+    TypeError
+        If the input is not an xarray Dataset.
+    ValueError
+        If the dataset is missing required data variables or dimensions,
+        or if any required dimensions are missing for any data variable.
+
+    Notes
+    -----
+    The dataset can have other data variables and dimensions, but only the
+    required ones are checked.
+
+    """
+
+    # Minimum requirements for a bbox dataset holding tracks
+    # Should not be modified after initialization
+    required_dims: ClassVar[set] = {"image_id", "space", "id"}
+    required_data_vars: ClassVar[dict[str, set]] = {
+        "position": {"image_id", "space", "id"},
+        "shape": {"image_id", "space", "id"},
+        "category": {"image_id", "id"},
+        "confidence": {"image_id", "id"},
+    }

--- a/tests/test_unit/test_io_tracks/test_tracks.py
+++ b/tests/test_unit/test_io_tracks/test_tracks.py
@@ -43,8 +43,8 @@ def _make_movement_bbox_dataset(
     )
 
 
-def test_from_movement_bboxes_converts_to_valid_tracks_dataset():
-    """from_movement_bboxes output passes ValidBboxTracksDataset."""
+def test_from_movement_bboxes():
+    """Conversion produces a dataset that passes ValidBboxTracksDataset."""
     movement_ds = _make_movement_bbox_dataset()
 
     ds_tracks = from_movement_bboxes(movement_ds)
@@ -63,8 +63,8 @@ def test_from_movement_bboxes_converts_to_valid_tracks_dataset():
     assert ds_tracks.category.shape == (3, 2)
 
 
-def test_from_movement_bboxes_forwards_category_and_confidence_when_present():
-    """When movement dataset has category, it is forwarded; confidence same."""
+def test_from_movement_bboxes_forwards_category_confidence():
+    """Category and confidence forwarded when present in movement dataset."""
     movement_ds = _make_movement_bbox_dataset(has_category=True)
 
     ds_tracks = from_movement_bboxes(movement_ds)
@@ -75,7 +75,7 @@ def test_from_movement_bboxes_forwards_category_and_confidence_when_present():
     )
 
 
-def test_from_movement_bboxes_fills_missing_category_and_confidence():
+def test_from_movement_bboxes_fills_defaults():
     """Missing category/confidence are filled with -1 and NaN."""
     movement_ds = _make_movement_bbox_dataset(
         has_category=False, has_confidence=False
@@ -87,8 +87,8 @@ def test_from_movement_bboxes_fills_missing_category_and_confidence():
     assert np.isnan(ds_tracks.confidence.values).all()
 
 
-def test_from_movement_bboxes_raises_when_dim_missing():
-    """from_movement_bboxes raises ValueError when required dims missing."""
+def test_from_movement_bboxes_error_missing_dims():
+    """ValueError when input is missing required dimensions."""
     movement_ds = _make_movement_bbox_dataset()
     movement_ds = movement_ds.rename({"time": "frame"})
 
@@ -99,8 +99,8 @@ def test_from_movement_bboxes_raises_when_dim_missing():
     assert "time" in str(excinfo.value) or "individuals" in str(excinfo.value)
 
 
-def test_from_movement_bboxes_raises_when_data_var_missing():
-    """from_movement_bboxes raises ValueError when position/shape missing."""
+def test_from_movement_bboxes_error_missing_shape():
+    """ValueError when input is missing position or shape."""
     movement_ds = _make_movement_bbox_dataset()
     movement_ds = movement_ds.drop_vars("shape")
 

--- a/tests/test_unit/test_io_tracks/test_tracks.py
+++ b/tests/test_unit/test_io_tracks/test_tracks.py
@@ -1,0 +1,111 @@
+"""Tests for :mod:`ethology.io.tracks`."""
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from ethology.io.tracks import from_movement_bboxes
+from ethology.validators.detections import ValidBboxTracksDataset
+
+
+def _make_movement_bbox_dataset(
+    n_time=3,
+    n_individuals=2,
+    has_category=False,
+    has_confidence=True,
+) -> xr.Dataset:
+    """Build a minimal movement-style bbox dataset for tests."""
+    time = np.arange(n_time)
+    individuals = np.arange(n_individuals)
+    space = ["x", "y"]
+
+    position = np.zeros((n_time, len(space), n_individuals))
+    shape = np.ones_like(position)
+    data_vars = {
+        "position": (["time", "space", "individuals"], position),
+        "shape": (["time", "space", "individuals"], shape),
+    }
+    if has_category:
+        data_vars["category"] = (
+            ["time", "individuals"],
+            np.zeros((n_time, n_individuals), dtype=int),
+        )
+    if has_confidence:
+        data_vars["confidence"] = (
+            ["time", "individuals"],
+            np.full((n_time, n_individuals), 0.5),
+        )
+
+    return xr.Dataset(
+        data_vars=data_vars,
+        coords={"time": time, "space": space, "individuals": individuals},
+        attrs={"time_unit": "frames"},
+    )
+
+
+def test_from_movement_bboxes_converts_to_valid_tracks_dataset():
+    """from_movement_bboxes output passes ValidBboxTracksDataset."""
+    movement_ds = _make_movement_bbox_dataset()
+
+    ds_tracks = from_movement_bboxes(movement_ds)
+
+    ValidBboxTracksDataset(dataset=ds_tracks)
+    assert set(ds_tracks.dims) >= {"image_id", "space", "id"}
+    assert np.array_equal(
+        ds_tracks.coords["image_id"].values, movement_ds.time
+    )
+    assert np.array_equal(
+        ds_tracks.coords["id"].values, movement_ds.individuals
+    )
+    assert np.allclose(ds_tracks.position.values, movement_ds.position.values)
+    assert np.allclose(ds_tracks.shape.values, movement_ds.shape.values)
+    assert ds_tracks.confidence.shape == (3, 2)
+    assert ds_tracks.category.shape == (3, 2)
+
+
+def test_from_movement_bboxes_forwards_category_and_confidence_when_present():
+    """When movement dataset has category, it is forwarded; confidence same."""
+    movement_ds = _make_movement_bbox_dataset(has_category=True)
+
+    ds_tracks = from_movement_bboxes(movement_ds)
+
+    assert np.allclose(ds_tracks.category.values, movement_ds.category.values)
+    assert np.allclose(
+        ds_tracks.confidence.values, movement_ds.confidence.values
+    )
+
+
+def test_from_movement_bboxes_fills_missing_category_and_confidence():
+    """Missing category/confidence are filled with -1 and NaN."""
+    movement_ds = _make_movement_bbox_dataset(
+        has_category=False, has_confidence=False
+    )
+
+    ds_tracks = from_movement_bboxes(movement_ds)
+
+    assert (ds_tracks.category.values == -1).all()
+    assert np.isnan(ds_tracks.confidence.values).all()
+
+
+def test_from_movement_bboxes_raises_when_dim_missing():
+    """from_movement_bboxes raises ValueError when required dims missing."""
+    movement_ds = _make_movement_bbox_dataset()
+    movement_ds = movement_ds.rename({"time": "frame"})
+
+    with pytest.raises(ValueError) as excinfo:
+        from_movement_bboxes(movement_ds)
+
+    assert "dimensions" in str(excinfo.value)
+    assert "time" in str(excinfo.value) or "individuals" in str(excinfo.value)
+
+
+def test_from_movement_bboxes_raises_when_data_var_missing():
+    """from_movement_bboxes raises ValueError when position/shape missing."""
+    movement_ds = _make_movement_bbox_dataset()
+    movement_ds = movement_ds.drop_vars("shape")
+
+    with pytest.raises(ValueError) as excinfo:
+        from_movement_bboxes(movement_ds)
+
+    assert "data variables" in str(excinfo.value)
+    assert "shape" in str(excinfo.value)

--- a/tests/test_unit/test_io_tracks/test_tracks.py
+++ b/tests/test_unit/test_io_tracks/test_tracks.py
@@ -59,8 +59,9 @@ def test_from_movement_bboxes():
     )
     assert np.allclose(ds_tracks.position.values, movement_ds.position.values)
     assert np.allclose(ds_tracks.shape.values, movement_ds.shape.values)
-    assert ds_tracks.confidence.shape == (3, 2)
-    assert ds_tracks.category.shape == (3, 2)
+    n_time, n_ids = movement_ds.sizes["time"], movement_ds.sizes["individuals"]
+    assert ds_tracks.confidence.shape == (n_time, n_ids)
+    assert ds_tracks.category.shape == (n_time, n_ids)
 
 
 def test_from_movement_bboxes_forwards_category_confidence():
@@ -109,3 +110,15 @@ def test_from_movement_bboxes_error_missing_shape():
 
     assert "data variables" in str(excinfo.value)
     assert "shape" in str(excinfo.value)
+
+
+def test_from_movement_bboxes_error_missing_position():
+    """ValueError when input is missing position."""
+    movement_ds = _make_movement_bbox_dataset()
+    movement_ds = movement_ds.drop_vars("position")
+
+    with pytest.raises(ValueError) as excinfo:
+        from_movement_bboxes(movement_ds)
+
+    assert "data variables" in str(excinfo.value)
+    assert "position" in str(excinfo.value)

--- a/tests/test_unit/test_validators/test_detections.py
+++ b/tests/test_unit/test_validators/test_detections.py
@@ -258,7 +258,7 @@ def test_validator_bbox_detections_dataset(
 
     if excinfo:
         error_msg = str(excinfo.value)
-        assert error_msg in expected_error_message
+        assert expected_error_message in error_msg
     else:
         assert validator.dataset is dataset
         assert validator.required_dims == {"image_id", "space", "id"}
@@ -395,7 +395,7 @@ def test_validator_bbox_tracks_dataset(
 
     if excinfo:
         error_msg = str(excinfo.value)
-        assert error_msg in expected_error_message
+        assert expected_error_message in error_msg
     else:
         assert validator.dataset is dataset
         assert validator.required_dims == {"image_id", "space", "id"}

--- a/tests/test_unit/test_validators/test_detections.py
+++ b/tests/test_unit/test_validators/test_detections.py
@@ -4,7 +4,10 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from ethology.validators.detections import ValidBboxDetectionsDataset
+from ethology.validators.detections import (
+    ValidBboxDetectionsDataset,
+    ValidBboxTracksDataset,
+)
 
 
 @pytest.fixture
@@ -252,6 +255,143 @@ def test_validator_bbox_detections_dataset(
     # Run validation and check exception
     with expected_exception as excinfo:
         validator = ValidBboxDetectionsDataset(dataset=dataset)
+
+    if excinfo:
+        error_msg = str(excinfo.value)
+        assert error_msg in expected_error_message
+    else:
+        assert validator.dataset is dataset
+        assert validator.required_dims == {"image_id", "space", "id"}
+        assert validator.required_data_vars == {
+            "position": {"image_id", "space", "id"},
+            "shape": {"image_id", "space", "id"},
+            "category": {"image_id", "id"},
+            "confidence": {"image_id", "id"},
+        }
+
+
+@pytest.fixture
+def valid_bbox_tracks_dataset() -> xr.Dataset:
+    """Create a valid bbox tracks dataset for validation."""
+    image_ids = [0, 1, 2]
+    track_ids = [0, 1]
+    space_dims = ["x", "y"]
+
+    position_data = np.zeros((len(image_ids), len(space_dims), len(track_ids)))
+    shape_data = np.copy(position_data)
+    category_data = np.ones((len(image_ids), len(track_ids)))
+    confidence_data = np.zeros((len(image_ids), len(track_ids)))
+
+    ds = xr.Dataset(
+        data_vars={
+            "position": (["image_id", "space", "id"], position_data),
+            "shape": (["image_id", "space", "id"], shape_data),
+            "category": (["image_id", "id"], category_data),
+            "confidence": (["image_id", "id"], confidence_data),
+        },
+        coords={
+            "image_id": image_ids,
+            "space": space_dims,
+            "id": track_ids,
+        },
+    )
+    return ds
+
+
+@pytest.mark.parametrize(
+    "sample_dataset, expected_exception, expected_error_message",
+    [
+        (
+            "valid_bbox_tracks_dataset",
+            does_not_raise(),
+            "",
+        ),
+        (
+            xr.Dataset(
+                coords={
+                    "image_id": np.arange(3),
+                    "space": ["x", "y"],
+                    "id": np.arange(2),
+                },
+                data_vars={
+                    "position": (
+                        ["image_id", "space", "id"],
+                        np.zeros((3, 2, 2)),
+                    ),
+                    "shape": (
+                        ["image_id", "space", "id"],
+                        np.zeros((3, 2, 2)),
+                    ),
+                    "category": (["image_id", "id"], np.ones((3, 2))),
+                    "confidence": (["image_id", "id"], np.zeros((3, 2))),
+                },
+            ),
+            does_not_raise(),
+            "",
+        ),
+        (
+            {"position": [1, 2, 3], "shape": [4, 5, 6]},
+            pytest.raises(TypeError),
+            "Expected an xarray Dataset, but got <class 'dict'>.",
+        ),
+        (
+            xr.Dataset(
+                coords={
+                    "image_id": np.arange(3),
+                    "space": ["x", "y"],
+                    "id": np.arange(2),
+                },
+                data_vars={
+                    "position": (
+                        ["image_id", "space", "id"],
+                        np.zeros((3, 2, 2)),
+                    ),
+                    "shape": (
+                        ["image_id", "space", "id"],
+                        np.zeros((3, 2, 2)),
+                    ),
+                    "category": (["image_id", "id"], np.ones((3, 2))),
+                },
+            ),
+            pytest.raises(ValueError),
+            "Missing required data variables: ['confidence']",
+        ),
+        (
+            xr.Dataset(
+                coords={"image_id": np.arange(3), "id": np.arange(2)},
+                data_vars={
+                    "position": (["image_id", "id"], np.zeros((3, 2))),
+                    "shape": (["image_id", "id"], np.zeros((3, 2))),
+                    "category": (["image_id", "id"], np.ones((3, 2))),
+                    "confidence": (["image_id", "id"], np.zeros((3, 2))),
+                },
+            ),
+            pytest.raises(ValueError),
+            "Missing required dimensions: ['space']",
+        ),
+    ],
+    ids=[
+        "valid_bbox_tracks",
+        "valid_bbox_tracks_minimal",
+        "invalid_bbox_tracks_type",
+        "invalid_bbox_tracks_missing_confidence",
+        "invalid_bbox_tracks_missing_space_dim",
+    ],
+)
+def test_validator_bbox_tracks_dataset(
+    sample_dataset: str | xr.Dataset | dict,
+    expected_exception,
+    expected_error_message: str,
+    request: pytest.FixtureRequest,
+):
+    """Test bbox tracks dataset validation in various input scenarios."""
+    if isinstance(sample_dataset, str):
+        dataset = request.getfixturevalue(sample_dataset)
+    else:
+        dataset = sample_dataset
+
+    with expected_exception as excinfo:
+        validator = ValidBboxTracksDataset(dataset=dataset)
 
     if excinfo:
         error_msg = str(excinfo.value)


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/neuroinformatics-unit/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

We want ethology to support tracked detections (same individual across frames), so we can later add examples (e.g. boxMOT) and other workflows. Right now we only have annotations (per-frame boxes) and detections (per-frame + confidence). This PR adds the data model and one way to get data into it.

**What does this PR do?**

Adds `ValidBboxTracksDataset`: a validator that defines what a “tracks” dataset must look like (same structure as detections, but id means track/individual across frames).

Adds `ethology.io.tracks.from_movement_bboxes`: a function that takes a movement bbox dataset and turns it into an ethology tracks dataset (renames dims, fills missing category/confidence if needed, validates the result).

## References
Please reference any existing issues/PRs that relate to this PR.

issue [here](https://github.com/neuroinformatics-unit/ethology/issues/14#issuecomment-3980839328)

## How has this PR been tested?

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.
Added required tests 

## Is this a breaking change?

If this PR breaks any existing functionality, please explain how and why.

No. This only adds new code (validator + loader + tests).

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the
documentation has been updated.

The new module and function will appear in the API docs once the API index is generated (same as other modules). 

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
