### PR TITLE
Preserve original COCO image IDs

### DIFF
--- a/ethology/io/annotations/load_bboxes.py
+++ b/ethology/io/annotations/load_bboxes.py
@@ -118,9 +118,11 @@ def from_files(
         df_all = _df_from_single_file(file_paths, format=format)
 
     # Get maps to set as dataset attributes
-    map_image_id_to_filename, map_category_to_str = (
-        _get_map_attributes_from_df(df_all)
-    )
+    (
+        map_image_id_to_filename,
+        map_category_to_str,
+        map_image_id_to_original_coco_id,
+    ) = _get_map_attributes_from_df(df_all)
 
     # Convert dataframe to xarray dataset
     ds = _df_to_xarray_ds(df_all)
@@ -132,6 +134,7 @@ def from_files(
         "images_directories": images_dirs,
         "map_category_to_str": map_category_to_str,
         "map_image_id_to_filename": map_image_id_to_filename,
+        "map_image_id_to_original_coco_id": map_image_id_to_original_coco_id,
     }
 
     return ds
@@ -139,7 +142,7 @@ def from_files(
 
 def _get_map_attributes_from_df(
     df: DataFrame[ValidBboxAnnotationsDataFrame],
-) -> tuple[dict, dict]:
+) -> tuple[dict, dict, dict]:
     """Get the map attributes from the dataframe.
 
     Parameters
@@ -173,7 +176,22 @@ def _get_map_attributes_from_df(
         # sort by category_id
         map_category_to_str = dict(sorted(map_category_to_str.items()))
 
-    return (map_image_id_to_filename, map_category_to_str)
+        # extract original COCO image ID mapping
+        #  if present in the dataframe
+        map_image_id_to_original_coco_id = {}
+        if "original_coco_image_id" in df.columns:
+            coco_id_df = df[
+                ["image_id", "original_coco_image_id"]
+            ].drop_duplicates()
+            map_image_id_to_original_coco_id = coco_id_df.set_index(
+                "image_id"
+            ).to_dict()["original_coco_image_id"]
+
+    return (
+        map_image_id_to_filename,
+        map_category_to_str,
+        map_image_id_to_original_coco_id,
+    )
 
 
 @pa.check_types
@@ -501,6 +519,12 @@ def _df_rows_from_valid_COCO_file(file_path: Path) -> list[dict]:
             sorted(data_dict["images"], key=lambda x: x["file_name"])
         )
     }
+
+    # ethology 0-based id → original COCO image id
+    # This is needed so save_bboxes can restore original IDs on export
+    map_img_id_ethology_to_coco = {
+        v: k for k, v in map_img_id_coco_to_ethology.items()
+    }
     map_img_id_coco_to_filename = {
         img_dict["id"]: img_dict["file_name"]
         for img_dict in data_dict["images"]
@@ -548,6 +572,9 @@ def _df_rows_from_valid_COCO_file(file_path: Path) -> list[dict]:
             "supercategory": supercategory,  # if not defined, set to ""
             "category": category,
             "category_id": category_id,
+            "original_coco_image_id": map_img_id_ethology_to_coco[
+                img_id_ethology
+            ],
             # in COCO files, the category_id is always a 1-based integer
         }
 

--- a/ethology/io/annotations/save_bboxes.py
+++ b/ethology/io/annotations/save_bboxes.py
@@ -192,9 +192,21 @@ def _add_COCO_data_to_df(
     whole dataset.
 
     """
+    # Make a copy to avoid mutating the caller's DataFrame.
+    # Without this modifying df["image_id"] below would change
+    # the original df_raw
+    df = df.copy()
+
     # image filename
     map_image_id_to_filename = ds_attrs["map_image_id_to_filename"]
     df["image_filename"] = df["image_id"].map(map_image_id_to_filename)
+
+    # Use original COCO image IDs
+    # If not available (e.g. dataset loaded from VIA format), fall back
+    # to ethology 0-based image IDs.
+    map_original_coco_id = ds_attrs.get("map_image_id_to_original_coco_id", {})
+    if map_original_coco_id:
+        df["image_id"] = df["image_id"].map(map_original_coco_id).astype(int)
 
     # image width and height
     if all(col in df.columns for col in ["image_shape_x", "image_shape_y"]):
@@ -261,6 +273,12 @@ def _add_COCO_data_to_df(
     df = df.loc[
         df.astype(str).drop_duplicates(ignore_index=True).index
     ]  # need to serialise lists first before dropping duplicates
+
+    # enforce schema dtypes
+    df["annotation_id"] = df["annotation_id"].astype(int)
+    df["image_id"] = df["image_id"].astype(int)
+    df["category_id"] = df["category_id"].astype(int)
+    df["iscrowd"] = df["iscrowd"].astype(int)
 
     return df
 

--- a/tests/test_unit/test_io_annotations/test_load_bboxes.py
+++ b/tests/test_unit/test_io_annotations/test_load_bboxes.py
@@ -19,6 +19,7 @@ from ethology.io.annotations.load_bboxes import (
     _get_image_shape_attr_as_integer,
     from_files,
 )
+from ethology.io.annotations.save_bboxes import to_COCO_file
 
 
 def check_if_file_includes_image_shape_data(
@@ -188,6 +189,7 @@ def assert_dataframe(
     expected_supercategories: str | list[str] | None = None,
     expected_categories: str | list[str] | None = None,
     expected_annots_per_image: int | None = None,
+    extra_columns: list[str] | None = None,
 ):
     """Check that the dataframe has the expected shape and content."""
     # Check shape of dataframe
@@ -201,22 +203,25 @@ def assert_dataframe(
     assert len(df["image_filename"].unique()) == expected_n_images
     assert len(df["image_id"].unique()) == expected_n_images
 
+    # expected columns list - base columns + any extras
+    expected_cols = [
+        "image_filename",
+        "image_id",
+        "x_min",
+        "y_min",
+        "width",
+        "height",
+        "supercategory",
+        "category",
+        "category_id",
+        "image_width",
+        "image_height",
+    ]
+    if extra_columns:
+        expected_cols = expected_cols + extra_columns
+
     # Check columns are as expected
-    assert sorted(df.columns.tolist()) == sorted(
-        [
-            "image_filename",
-            "image_id",
-            "x_min",
-            "y_min",
-            "width",
-            "height",
-            "supercategory",
-            "category",
-            "category_id",
-            "image_width",
-            "image_height",
-        ]
-    )
+    assert sorted(df.columns.tolist()) == sorted(expected_cols)
 
     # Check supercategories if all annotations have the same supercategory
     if expected_supercategories:
@@ -401,6 +406,7 @@ def test_df_from_multiple_files(
         expected_n_images=n_images,
         expected_supercategories="animal",
         expected_categories="crab",
+        extra_columns=["original_coco_image_id"] if format == "COCO" else None,
     )
 
 
@@ -488,6 +494,7 @@ def test_df_from_single_file(
         expected_annots_per_image=1
         if expected_n_unique_images_with_annotations < 5
         else None,
+        extra_columns=["original_coco_image_id"] if format == "COCO" else None,
     )
 
     # Check image shape data is present if present in the input file
@@ -536,6 +543,7 @@ def test_df_from_single_file_duplicates(
         expected_n_images=expected_n_images,
         expected_supercategories="animal",
         expected_categories="crab",
+        extra_columns=["original_coco_image_id"] if format == "COCO" else None,
     )
 
 
@@ -1023,3 +1031,59 @@ def test_get_image_shape_attr_as_integer(
         _get_image_shape_attr_as_integer(file_attrs, attr_name)
         == expected_value
     )
+
+
+def test_original_coco_image_ids_stored_in_attrs(
+    annotations_test_data: dict,
+):
+    """When loading a COCO file where image IDs are not 0-based
+    (e.g. 5, 23, 99), the Dataset attrs must store a
+    mapping from ethology 0-based IDs back to original COCO IDs.
+    """
+    # Use an existing small COCO test file
+    # image IDs in this file start at 1, not 0
+    filepath = annotations_test_data["small_bboxes_COCO.json"]
+    ds = from_files(filepath, format="COCO")
+
+    # The attr must exist
+    assert "map_image_id_to_original_coco_id" in ds.attrs
+
+    # must have one entry per image
+    n_images = ds.sizes["image_id"]
+    assert len(ds.attrs["map_image_id_to_original_coco_id"]) == n_images
+
+
+def test_round_trip_preserves_original_coco_image_ids(
+    annotations_test_data: dict,
+    tmp_path: Path,
+):
+    """Load COCO → save COCO → reload: the saved file must have the
+    same image IDs as the original file.
+    """
+    input_file = annotations_test_data["small_bboxes_COCO.json"]
+
+    # Read original image IDs from the input file directly
+    with open(input_file) as f:
+        original_coco = json.load(f)
+    original_image_ids = {img["id"] for img in original_coco["images"]}
+
+    # Load → save
+    ds = from_files(input_file, format="COCO")
+    output_file = to_COCO_file(ds, output_filepath=tmp_path / "output.json")
+
+    # Read saved file
+    with open(output_file) as f:
+        saved_coco = json.load(f)
+    saved_image_ids = {img["id"] for img in saved_coco["images"]}
+
+    # The saved image IDs must match the original
+    assert saved_image_ids == original_image_ids, (
+        f"Original COCO image IDs {original_image_ids} were not "
+        f"preserved in saved file. Got: {saved_image_ids}"
+    )
+
+    # Also check annotation image_ids are preserved
+    saved_ann_image_ids = {
+        ann["image_id"] for ann in saved_coco["annotations"]
+    }
+    assert saved_ann_image_ids.issubset(original_image_ids)


### PR DESCRIPTION
Closes #97 

Summary-
This PR preserves original COCO image IDs when loading and saving bounding box annotations.
Previously, image IDs were reindexed to 0-based values during loading, and exporting back to COCO did not restore the original IDs. This caused mismatches with external datasets expecting the original COCO identifiers.
Changes
    -Store original_coco_image_id when loading COCO files
    -Save mapping map_image_id_to_original_coco_id in dataset attributes
    -Restore original image IDs when exporting to COCO
    -Ensure fallback to ethology IDs when mapping is unavailable (e.g. VIA format)
    -Added tests to validate mapping and round-trip behaviour
Tests Added.
COCO input → preserves original IDs on export.
VIA input → unchanged behaviour (no mapping)

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
