### PR TITLE
Add function to extract evenly spaced frames from a video

### DIFF
--- a/ethology/io/__init__.py
+++ b/ethology/io/__init__.py
@@ -1,1 +1,5 @@
-""" Load and export `ethology` datasets."""
+"""I/O utilities for ethology."""
+
+from ethology.io.video import extract_frames_uniform
+
+__all__ = ["extract_frames_uniform"]

--- a/ethology/io/video.py
+++ b/ethology/io/video.py
@@ -1,0 +1,173 @@
+"""Functions for reading and extracting frames from video files."""
+
+from pathlib import Path
+
+import cv2  # type: ignore[import-untyped]
+import numpy as np
+
+
+def _validate_time_interval(
+    start_time: float,
+    end_time: float,
+    duration: float,
+) -> None:
+    """Validate the requested time interval against the video duration.
+
+    Parameters
+    ----------
+    start_time : float
+        Start of the sampling interval in seconds.
+    end_time : float
+        End of the sampling interval in seconds.
+    duration : float
+        Total duration of the video in seconds.
+
+    Raises
+    ------
+    ValueError
+        If ``start_time`` is negative, ``end_time`` exceeds the video
+        duration, or ``start_time`` is greater than or equal to
+        ``end_time``.
+
+    """
+    if start_time < 0.0:
+        raise ValueError(
+            f"'start_time' must be non-negative, got {start_time}."
+        )
+    if end_time > duration:
+        raise ValueError(
+            f"'end_time' ({end_time} s) exceeds the video "
+            f"duration ({duration:.3f} s)."
+        )
+    if start_time >= end_time:
+        raise ValueError(
+            f"'start_time' ({start_time} s) must be strictly "
+            f"less than 'end_time' ({end_time} s)."
+        )
+
+
+def extract_frames_uniform(
+    video_path: Path | str,
+    n_frames: int,
+    output_dir: Path | str,
+    start_time: float | None = None,
+    end_time: float | None = None,
+) -> list[Path]:
+    """Extract evenly spaced frames from a video file.
+
+    Frames are sampled at timestamps computed using
+    :func:`numpy.linspace` over the interval
+    ``[start_time, end_time]``. Each frame is saved as a JPEG image
+    whose filename encodes both its index and its timestamp.
+
+    Parameters
+    ----------
+    video_path : pathlib.Path or str
+        Path to the input video file.
+    n_frames : int
+        Number of frames to extract. Must be at least 1.
+    output_dir : pathlib.Path or str
+        Directory in which to save the extracted frame images.
+        It is created automatically if it does not already exist.
+    start_time : float, optional
+        Start of the sampling interval in seconds. If ``None``,
+        defaults to ``0.0`` (the beginning of the video).
+    end_time : float, optional
+        End of the sampling interval in seconds. If ``None``,
+        defaults to the total duration of the video.
+
+    Returns
+    -------
+    list of pathlib.Path
+        Paths to the saved JPEG frame images, ordered from the
+        earliest to the latest extracted timestamp.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``video_path`` does not point to an existing file.
+    ValueError
+        If ``n_frames`` is less than 1.
+    ValueError
+        If the video file cannot be opened by OpenCV.
+    ValueError
+        If ``start_time`` is negative.
+    ValueError
+        If ``end_time`` exceeds the video duration.
+    ValueError
+        If ``start_time`` is greater than or equal to ``end_time``.
+
+    Notes
+    -----
+    Output files are named ``frame_NNNN_tT.TTTs.jpg``, where
+    ``NNNN`` is the zero-padded extraction index and ``T.TTT`` is
+    the timestamp in seconds.
+
+    Examples
+    --------
+    Extract 5 evenly spaced frames from the entire video:
+
+    >>> from pathlib import Path
+    >>> from ethology.io.video import extract_frames_uniform
+    >>> paths = extract_frames_uniform(
+    ...     video_path="recording.mp4",
+    ...     n_frames=5,
+    ...     output_dir="frames/",
+    ... )
+
+    Extract 10 frames from the two-second window [1.0, 3.0] s:
+
+    >>> paths = extract_frames_uniform(
+    ...     video_path="recording.mp4",
+    ...     n_frames=10,
+    ...     output_dir="frames/",
+    ...     start_time=1.0,
+    ...     end_time=3.0,
+    ... )
+
+    """
+    video_path = Path(video_path)
+    output_dir = Path(output_dir)
+
+    if not video_path.is_file():
+        raise FileNotFoundError(f"Video file not found: '{video_path}'.")
+    if n_frames < 1:
+        raise ValueError(f"'n_frames' must be at least 1, got {n_frames}.")
+
+    cap = cv2.VideoCapture(str(video_path))
+    if not cap.isOpened():
+        raise ValueError(
+            f"Could not open video file: '{video_path}'. "
+            "The file may be corrupted or use an unsupported codec."
+        )
+
+    try:
+        fps: float = cap.get(cv2.CAP_PROP_FPS)
+        total_frames: int = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        duration: float = total_frames / fps
+
+        if start_time is None:
+            start_time = 0.0
+        if end_time is None:
+            end_time = duration
+
+        _validate_time_interval(start_time, end_time, duration)
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        timestamps: np.ndarray = np.linspace(start_time, end_time, n_frames)
+
+        output_paths: list[Path] = []
+        for i, t in enumerate(timestamps):
+            frame_idx: int = min(int(t * fps), total_frames - 1)
+            cap.set(cv2.CAP_PROP_POS_FRAMES, float(frame_idx))
+            ret, frame = cap.read()
+            if ret:
+                filename = f"frame_{i:04d}_t{t:.3f}s.jpg"
+                frame_path = output_dir / filename
+                cv2.imwrite(str(frame_path), frame)
+                output_paths.append(frame_path)
+    finally:
+        cap.release()
+
+    return output_paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 ]
 dependencies = [
   "movement>=0.13.0",
+  "opencv-python",
   "pandera[pandas]",
   "pycocotools",
   "scikit-learn",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import pytest
 # load fixtures defined as modules
 pytest_plugins = [
     "tests.fixtures.annotations",
+    "tests.fixtures.video",
 ]
 
 GIN_TEST_DATA_REPO = (

--- a/tests/fixtures/video.py
+++ b/tests/fixtures/video.py
@@ -1,0 +1,52 @@
+"""Pytest fixtures shared across video tests."""
+
+import cv2  # type: ignore[import-untyped]
+import numpy as np
+import pytest
+
+
+@pytest.fixture()
+def sample_video(tmp_path: pytest.TempPathFactory) -> dict:
+    """Create a synthetic video file for testing.
+
+    The video has 30 frames at 10 fps (3 seconds total),
+    with a 64x64 resolution. Each frame has a distinct colour
+    so that extraction results can be verified visually.
+
+    Returns
+    -------
+    dict
+        A dictionary with keys:
+        ``path`` (pathlib.Path), ``fps`` (float),
+        ``n_frames`` (int), ``duration`` (float),
+        ``width`` (int), ``height`` (int).
+
+    """
+    fps = 10.0
+    n_frames = 30
+    width, height = 64, 64
+    duration = n_frames / fps
+
+    video_path = tmp_path / "sample_video.avi"
+    fourcc = cv2.VideoWriter_fourcc(*"MJPG")
+    writer = cv2.VideoWriter(str(video_path), fourcc, fps, (width, height))
+
+    for i in range(n_frames):
+        # Each frame has a unique blue-channel value so frames
+        # are visually distinguishable.
+        frame = np.zeros((height, width, 3), dtype=np.uint8)
+        frame[:, :, 0] = int(255 * i / n_frames)  # blue
+        frame[:, :, 1] = 100  # green (constant)
+        frame[:, :, 2] = 50  # red   (constant)
+        writer.write(frame)
+
+    writer.release()
+
+    return {
+        "path": video_path,
+        "fps": fps,
+        "n_frames": n_frames,
+        "duration": duration,
+        "width": width,
+        "height": height,
+    }

--- a/tests/test_unit/test_io/test_video.py
+++ b/tests/test_unit/test_io/test_video.py
@@ -1,0 +1,239 @@
+"""Tests for ethology.io.video."""
+
+from pathlib import Path
+
+import pytest
+
+from ethology.io.video import extract_frames_uniform
+
+# ------------------------------------------------------------------ #
+#  Valid-input tests                                                   #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.parametrize(
+    "n_frames",
+    [1, 5, 10, 30],
+    ids=["1_frame", "5_frames", "10_frames", "30_frames"],
+)
+def test_extract_frames_uniform_returns_correct_count(
+    n_frames: int,
+    sample_video: dict,
+    tmp_path: Path,
+) -> None:
+    """Extracting n_frames from a video returns exactly n_frames paths."""
+    output_dir = tmp_path / "frames"
+    paths = extract_frames_uniform(
+        video_path=sample_video["path"],
+        n_frames=n_frames,
+        output_dir=output_dir,
+    )
+    assert len(paths) == n_frames
+
+
+@pytest.mark.parametrize(
+    "n_frames",
+    [1, 5, 10],
+    ids=["1_frame", "5_frames", "10_frames"],
+)
+def test_extract_frames_uniform_files_exist(
+    n_frames: int,
+    sample_video: dict,
+    tmp_path: Path,
+) -> None:
+    """Every path returned by extract_frames_uniform points to a real file."""
+    output_dir = tmp_path / "frames"
+    paths = extract_frames_uniform(
+        video_path=sample_video["path"],
+        n_frames=n_frames,
+        output_dir=output_dir,
+    )
+    for p in paths:
+        assert p.is_file(), f"Expected file to exist: {p}"
+
+
+@pytest.mark.parametrize(
+    "n_frames",
+    [1, 5],
+    ids=["1_frame", "5_frames"],
+)
+def test_extract_frames_uniform_output_filenames(
+    n_frames: int,
+    sample_video: dict,
+    tmp_path: Path,
+) -> None:
+    """Output filenames follow the pattern frame_NNNN_tT.TTTs.jpg."""
+    output_dir = tmp_path / "frames"
+    paths = extract_frames_uniform(
+        video_path=sample_video["path"],
+        n_frames=n_frames,
+        output_dir=output_dir,
+    )
+    for i, p in enumerate(paths):
+        assert p.suffix == ".jpg"
+        assert p.name.startswith(f"frame_{i:04d}_t")
+
+
+def test_extract_frames_uniform_output_dir_created(
+    sample_video: dict,
+    tmp_path: Path,
+) -> None:
+    """extract_frames_uniform creates output_dir if it does not exist."""
+    output_dir = tmp_path / "new_dir" / "nested_dir"
+    assert not output_dir.exists()
+    extract_frames_uniform(
+        video_path=sample_video["path"],
+        n_frames=3,
+        output_dir=output_dir,
+    )
+    assert output_dir.is_dir()
+
+
+def test_extract_frames_uniform_output_in_correct_dir(
+    sample_video: dict,
+    tmp_path: Path,
+) -> None:
+    """All returned paths are located inside output_dir."""
+    output_dir = tmp_path / "frames"
+    paths = extract_frames_uniform(
+        video_path=sample_video["path"],
+        n_frames=5,
+        output_dir=output_dir,
+    )
+    for p in paths:
+        assert p.parent == output_dir
+
+
+# ------------------------------------------------------------------ #
+#  Time-interval tests                                                 #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.parametrize(
+    "start_time, end_time, n_frames",
+    [
+        (0.0, 1.0, 5),
+        (1.0, 2.0, 3),
+        (0.5, 2.5, 8),
+    ],
+    ids=[
+        "first_second",
+        "middle_second",
+        "middle_two_seconds",
+    ],
+)
+def test_extract_frames_uniform_with_time_interval(
+    start_time: float,
+    end_time: float,
+    n_frames: int,
+    sample_video: dict,
+    tmp_path: Path,
+) -> None:
+    """Extracting with explicit start/end returns the correct frame count."""
+    output_dir = tmp_path / "frames"
+    paths = extract_frames_uniform(
+        video_path=sample_video["path"],
+        n_frames=n_frames,
+        output_dir=output_dir,
+        start_time=start_time,
+        end_time=end_time,
+    )
+    assert len(paths) == n_frames
+    for p in paths:
+        assert p.is_file()
+
+
+# ------------------------------------------------------------------ #
+#  Invalid-input tests                                                 #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.parametrize(
+    "kwargs_override, expected_exception, error_fragment",
+    [
+        # video_path does not exist
+        (
+            {"video_path": "non_existent_video.mp4"},
+            pytest.raises(FileNotFoundError),
+            "Video file not found",
+        ),
+        # n_frames = 0
+        (
+            {"n_frames": 0},
+            pytest.raises(ValueError),
+            "'n_frames' must be at least 1",
+        ),
+        # n_frames negative
+        (
+            {"n_frames": -3},
+            pytest.raises(ValueError),
+            "'n_frames' must be at least 1",
+        ),
+        # start_time negative
+        (
+            {"start_time": -1.0},
+            pytest.raises(ValueError),
+            "'start_time' must be non-negative",
+        ),
+        # end_time beyond video duration
+        (
+            {"end_time": 9999.0},
+            pytest.raises(ValueError),
+            "'end_time'",
+        ),
+        # start_time equal to end_time
+        (
+            {"start_time": 1.0, "end_time": 1.0},
+            pytest.raises(ValueError),
+            "'start_time'",
+        ),
+        # start_time greater than end_time
+        (
+            {"start_time": 2.0, "end_time": 1.0},
+            pytest.raises(ValueError),
+            "'start_time'",
+        ),
+    ],
+    ids=[
+        "video_not_found",
+        "n_frames_zero",
+        "n_frames_negative",
+        "start_time_negative",
+        "end_time_exceeds_duration",
+        "start_equals_end",
+        "start_greater_than_end",
+    ],
+)
+def test_extract_frames_uniform_invalid_inputs(
+    kwargs_override: dict,
+    expected_exception: pytest.raises,
+    error_fragment: str,
+    sample_video: dict,
+    tmp_path: Path,
+) -> None:
+    """extract_frames_uniform raises the expected error for invalid inputs."""
+    base_kwargs: dict = {
+        "video_path": sample_video["path"],
+        "n_frames": 5,
+        "output_dir": tmp_path / "frames",
+    }
+    base_kwargs.update(kwargs_override)
+
+    with expected_exception as excinfo:
+        extract_frames_uniform(**base_kwargs)
+
+    assert error_fragment in str(excinfo.value)
+
+
+def test_extract_frames_uniform_accepts_str_paths(
+    sample_video: dict,
+    tmp_path: Path,
+) -> None:
+    """extract_frames_uniform accepts plain strings for path arguments."""
+    output_dir = tmp_path / "frames"
+    paths = extract_frames_uniform(
+        video_path=str(sample_video["path"]),
+        n_frames=3,
+        output_dir=str(output_dir),
+    )
+    assert len(paths) == 3


### PR DESCRIPTION
## Description

Adds `extract_frames_uniform` to `ethology.io.video` -- a function
that extracts a user-specified number of evenly spaced frames from a
video file, optionally restricted to a time interval
`[start_time, end_time]`.

## What is new

- `ethology/io/video.py` -- new module containing
  `extract_frames_uniform`. Timestamps are computed with
  `numpy.linspace` over the requested interval; each timestamp is
  converted to the nearest frame index and sought with
  `cv2.CAP_PROP_POS_FRAMES` for codec-agnostic reliability.
  Output frames are saved as JPEG files named
  `frame_NNNN_tT.TTTs.jpg`.
- `ethology/io/__init__.py` -- exports `extract_frames_uniform`.
- `tests/fixtures/video.py` -- fixture that builds a 30-frame
  synthetic AVI video (10 fps, 3 s, 64×64 px) in `tmp_path` for
  use in tests.
- `tests/test_unit/test_io/test_video.py` -- unit tests covering
  correct frame counts, file existence, filename format, automatic
  output-directory creation, time-interval extraction, and all
  invalid-input error paths.
- `opencv-python` added to project dependencies.

## How to verify
pytest tests/test_unit/test_io/test_video.py -v

## Checklist

- [x] New feature
- [x] References issue #6
- [x] Tests added for all new functionality
- [x] Docstrings follow numpydoc style
- [x] Pre-commit hooks pass