### PR TITLE
Migrate dev and docs from optional dependencies to PEP 735 dependency groups

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -35,7 +35,7 @@ jobs:
     name: Build Sphinx Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: neuroinformatics-unit/actions/build_sphinx_docs@main
+      - uses: neuroinformatics-unit/actions/build_sphinx_docs@v2
         with:
           python-version: 3.13 # default for the action is 3.x
           use-make: true

--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -35,7 +35,7 @@ jobs:
     name: Build Sphinx Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: neuroinformatics-unit/actions/build_sphinx_docs@v2
+      - uses: neuroinformatics-unit/actions/build_sphinx_docs@main
         with:
           python-version: 3.13 # default for the action is 3.x
           use-make: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,15 @@ and pip-installing it in editable mode with the required dependencies:
 git clone https://github.com/neuroinformatics-unit/ethology.git
 
 # then run from within the repository root folder:
-pip install -e .[dev]  # works on most shells
-pip install -e '.[dev]'  # works on zsh (the default shell on macOS)
+pip install -e . --group dev
 ```
-This should install all the dependencies needed for development, such as `pytest` and `pre-commit`. If you also want to edit the documentation and preview the changes locally, you will additionally need the `docs` extra dependencies. See [Editing the documentation](#editing-the-documentation) for more details.
+This will install all the dependencies needed for development, such as `pytest` and `pre-commit`.
+If you also want to [edit the documentation](#editing-the-documentation) and preview the changes locally, you will additionally need the `docs` dependencies.
+To install both `dev` and `docs` dependencies at once, use `--all-groups`:
+
+```sh
+pip install -e . --all-groups
+```
 
 Finally, install the [pre-commit hooks](https://pre-commit.com/):
 
@@ -140,8 +145,7 @@ To edit the documentation, first clone the repository, and install `ethology` in
 
 Then, install a few additional dependencies in your development environment to be able to build the documentation locally. To do this, run the following command from the root of the repository:
 ```sh
-pip install -e .[docs]    # works on most shells
-pip install -e '.[docs]'  # works on zsh (default on macOS)
+pip install -e --group docs
 ```
 
 Now create a new branch, edit the documentation source files (`.md` or `.rst` in the `docs` folder),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 "User Support" = "https://github.com/neuroinformatics-unit/ethology/issues"
 
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
   "pytest",
   "pytest-cov",
@@ -151,7 +151,7 @@ python =
     3.13: py313
 
 [testenv]
-extras =
+dependency_groups =
     dev
 commands =
     pytest -v --color=yes --cov=ethology --cov-report=xml


### PR DESCRIPTION
## References
https://github.com/neuroinformatics-unit/movement/issues/955

## How has this PR been tested?
Tested in https://github.com/neuroinformatics-unit/movement/pull/956

## Does this PR require an update to the documentation?
Installation command has been updated.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)